### PR TITLE
A few fixes to CitrineDataRetrieval and added unit tests for retrieval

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 2.7.12
+    version: 3.5.2
 dependencies:
   override:
     - pip install --upgrade pip

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 3.5.2
+    version: 2.7.12
 dependencies:
   override:
     - pip install --upgrade pip

--- a/matminer/data_retrieval/retrieve_Citrine.py
+++ b/matminer/data_retrieval/retrieve_Citrine.py
@@ -120,7 +120,7 @@ class CitrineDataRetrieval:
                             prop_df = prop_df.pivot(columns='property.name', values='property.scalar')
                         elif 'property.matrix' in meas_normdf.columns:
                             prop_df = prop_df.pivot(columns='property.name', values='property.matrix')
-                        prop_df = prop_df.convert_objects(convert_numeric=True)  # Convert columns from object to num
+                        prop_df = prop_df.apply(pd.to_numeric) # Convert columns from object to num
                         # Making a single row DF of non-'measurement.property' columns
                         non_prop_df = pd.DataFrame()
                         non_prop_cols = [cols for cols in meas_normdf.columns if "property" not in cols]
@@ -132,7 +132,8 @@ class CitrineDataRetrieval:
                         units_df = pd.DataFrame()    # Get property unit and insert it as a dict
                         if 'property.units' in meas_normdf.columns:
                             curr_units = dict(zip(meas_normdf['property.name'], meas_normdf['property.units']))
-                            units_df['property.units'] = [curr_units]
+                            units_df['property.units'] = [curr_units] * len(meas_normdf)
+                            #import pdb; pdb.set_trace()
                             units_df.index = [counter] * len(meas_normdf)
                         meas_df = meas_df.append(pd.concat([prop_df, non_prop_df, units_df], axis=1))
 

--- a/matminer/data_retrieval/retrieve_Citrine.py
+++ b/matminer/data_retrieval/retrieve_Citrine.py
@@ -133,7 +133,6 @@ class CitrineDataRetrieval:
                         if 'property.units' in meas_normdf.columns:
                             curr_units = dict(zip(meas_normdf['property.name'], meas_normdf['property.units']))
                             units_df['property.units'] = [curr_units] * len(meas_normdf)
-                            #import pdb; pdb.set_trace()
                             units_df.index = [counter] * len(meas_normdf)
                         meas_df = meas_df.append(pd.concat([prop_df, non_prop_df, units_df], axis=1))
 

--- a/matminer/data_retrieval/retrieve_Citrine.py
+++ b/matminer/data_retrieval/retrieve_Citrine.py
@@ -120,7 +120,7 @@ class CitrineDataRetrieval:
                             prop_df = prop_df.pivot(columns='property.name', values='property.scalar')
                         elif 'property.matrix' in meas_normdf.columns:
                             prop_df = prop_df.pivot(columns='property.name', values='property.matrix')
-                        prop_df = prop_df.apply(pd.to_numeric) # Convert columns from object to num
+                        prop_df = prop_df.apply(pd.to_numeric, errors='ignore') # Convert columns from object to num
                         # Making a single row DF of non-'measurement.property' columns
                         non_prop_df = pd.DataFrame()
                         non_prop_cols = [cols for cols in meas_normdf.columns if "property" not in cols]

--- a/matminer/data_retrieval/retrieve_Citrine.py
+++ b/matminer/data_retrieval/retrieve_Citrine.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 """
 This package requires downloading an installing the citrination client:
 https://github.com/CitrineInformatics/python-citrination-client

--- a/matminer/data_retrieval/retrieve_Citrine.py
+++ b/matminer/data_retrieval/retrieve_Citrine.py
@@ -134,7 +134,7 @@ class CitrineDataRetrieval:
                         units_df = pd.DataFrame()    # Get property unit and insert it as a dict
                         if 'property.units' in meas_normdf.columns:
                             curr_units = dict(zip(meas_normdf['property.name'], meas_normdf['property.units']))
-                            units_df['property.units'] = [curr_units] * len(meas_normdf)
+                            units_df['property.units'] = curr_units
                             units_df.index = [counter] * len(meas_normdf)
                         meas_df = meas_df.append(pd.concat([prop_df, non_prop_df, units_df], axis=1))
 

--- a/matminer/data_retrieval/tests/test_retrieve_Citrine.py
+++ b/matminer/data_retrieval/tests/test_retrieve_Citrine.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+from __future__ import division, unicode_literals
+
+import unittest2 as unittest
+import os
+
+from matminer.data_retrieval.retrieve_Citrine import CitrineDataRetrieval
+
+api_key = os.environ.get('CITRINE_KEY', None)
+
+@unittest.skipIf(api_key is None,
+                 "CITRINE_KEY environment variable not set.")
+
+class MPResterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.cdr = CitrineDataRetrieval(api_key)
+
+    def test_get_data(self):
+        df = self.cdr.get_dataframe(contributor="OQMD", formula="GaN")
+
+
+if __name__=="__main__":
+    unittest.main()

--- a/matminer/data_retrieval/tests/test_retrieve_Citrine.py
+++ b/matminer/data_retrieval/tests/test_retrieve_Citrine.py
@@ -7,15 +7,15 @@ import os
 
 from matminer.data_retrieval.retrieve_Citrine import CitrineDataRetrieval
 
-api_key = os.environ.get('CITRINE_KEY', None)
+citrine_key = os.environ.get('CITRINE_KEY', None)
 
-@unittest.skipIf(api_key is None,
+@unittest.skipIf(citrine_key is None,
                  "CITRINE_KEY environment variable not set.")
 
-class MPResterTest(unittest.TestCase):
+class CitrineDataRetrievalTest(unittest.TestCase):
 
     def setUp(self):
-        self.cdr = CitrineDataRetrieval(api_key)
+        self.cdr = CitrineDataRetrieval(citrine_key)
 
     def test_get_data(self):
         df = self.cdr.get_dataframe(contributor="OQMD", formula="GaN")

--- a/matminer/data_retrieval/tests/test_retrieve_Citrine.py
+++ b/matminer/data_retrieval/tests/test_retrieve_Citrine.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from __future__ import division, unicode_literals
+from __future__ import division, unicode_literals, absolute_import
 
 import unittest2 as unittest
 import os

--- a/matminer/data_retrieval/tests/test_retrieve_MP.py
+++ b/matminer/data_retrieval/tests/test_retrieve_MP.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+from __future__ import division, unicode_literals
+
+import unittest2 as unittest
+import os
+
+from matminer.data_retrieval.retrieve_MP import MPDataRetrieval
+
+mapi_key = os.environ.get('MAPI_KEY', None)
+
+@unittest.skipIf(mapi_key is None,
+                 "MAPI_KEY environment variable not set.")
+
+class MPDataRetrievalTest(unittest.TestCase):
+
+    def setUp(self):
+        self.mpdr = MPDataRetrieval(mapi_key)
+
+    def test_get_data(self):
+        df = self.mpdr.get_dataframe(criteria={"material_id":"mp-23"},
+                properties=["structure"])
+
+if __name__=="__main__":
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas>=0.17.1
 pymatgen>=4.0
 unittest2==1.1.0
 pint
+citrination-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pandas>=0.17.1
 pymatgen>=4.0
 unittest2==1.1.0
 pint
-citrination-client
+citrination-client==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ tqdm>=3.7.1
 pandas>=0.17.1
 pymatgen>=4.0
 unittest2==1.1.0
-citrination-client==1.0.1
 pint
+-e git+https://github.com/CitrineInformatics/python-citrination-client@legacy#egg=python-citrination-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ tqdm>=3.7.1
 pandas>=0.17.1
 pymatgen>=4.0
 unittest2==1.1.0
-pint
 citrination-client==1.0.1
+pint


### PR DESCRIPTION
This PR fixes a few issues I was having with citrine data retrieval.  I went ahead and added a (very basic) unit test for CitrineDataRetrieval and MPDataRetrieval, following the convention in the MPRester unit test in which they are skipped without proper api credentials in the environment.

Also, as a side note, I had a bit of trouble with the citrine python API.  The PyPI versions of citrination-client do not work properly with MatMiner (nor does the master branch in their github repo).  I think users can figure it out by following the instructions at the link in the CitrineDataRetrieval docstring, but I figured I'd note it here just so it was on the radar.