### PR TITLE
Fist commit for coordination number algorithms

### DIFF
--- a/matminer/descriptors/examples/coordination_numbers.ipynb
+++ b/matminer/descriptors/examples/coordination_numbers.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from matminer.descriptors.structure_features import CN_OKeeffes, CN_OKeeffes_mod, CN_BrunnerReal, \\\n",
+    "                                                CN_BrunnerReciprocal, CN_BrunnerRelative, CN_ECoN"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Currently avaialble CN algorithms in MatMiner. \n",
+    "\n",
+    "Each algorithm starts with CN_ and is derived from the CNBase class.\n",
+    "\n",
+    "* **CN_Okeeffes:** Weighted Voronoi CNs (O'Keeffe's method).\n",
+    "* **CN_Okeeffes_mod:** A modified version of OKeeffe's algorithm.\n",
+    "* **CN_ECoN:** Effective Coordination Numbers, ECoN, (Hoppe's method).\n",
+    "* **CN_BrunnerReciprocal:** Brunner's method of largest reciprocal gap in interactomic distances.\n",
+    "* **CN_BrunnerRelative:** Brunner's method of largest relative gap in interactomic distances.\n",
+    "* **CN_BrunnerReal:** Brunner's method of largest gap in interactomic distances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Each algorithm is a class, which can be initialized with its own parameters\n",
+    "\n",
+    "okeeffe_params = {\"cutoff\": 10.0}\n",
+    "econ_parmas = {\"radius\": 10.0}\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example use of algorithms:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{u'As': 3.9999999982682555, u'Ga': 0.5381161641802799}\n",
+      "{u'As': 4}\n",
+      "{u'As': 4.0, u'Ga': 12.0}\n",
+      "{u'As': 4.0}\n",
+      "{u'As': 4.0, u'Ga': 12.0}\n",
+      "{u'As': 4.000000720303867, u'Ga': 1.896561960444926e-07}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Each algorithm takes a structure and site index as input and \n",
+    "# returns the coordination numbers for that site as a dict.\n",
+    "\n",
+    "\n",
+    "# Let's calculate CNs for site with index 0 in \"mp-2534\" from Materials Project using our algorithms:\n",
+    "\n",
+    "cn_methods = [CN_OKeeffes(params=okeeffe_params), CN_OKeeffes_mod(), CN_BrunnerReal(), \n",
+    "            CN_BrunnerReciprocal(), CN_BrunnerRelative(), CN_ECoN(params=econ_parmas)]\n",
+    "\n",
+    "test_mpid = \"mp-2534\"\n",
+    "from pymatgen import MPRester\n",
+    "with MPRester() as mp:\n",
+    "    test_struct = mp.get_structure_by_material_id(test_mpid)\n",
+    "\n",
+    "for cn_method in cn_methods:\n",
+    "    print cn_method.compute(test_struct, 0)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/matminer/descriptors/structure_features.py
+++ b/matminer/descriptors/structure_features.py
@@ -136,7 +136,8 @@ class CNBase:
 
     def __init__(self, params=None):
         """
-        :param params: (dict) of parameters to pass to compute method.
+        Args:
+            params: (dict) parameters to pass to compute method.
         """
         self._params = params if params else {}
         self._cns = {}
@@ -144,20 +145,23 @@ class CNBase:
     @abc.abstractmethod
     def compute(self, structure, n):
         """
-        :param structure: (Structure) a pymatgen Structure
-        :param n: (int) index of the atom in structure that the CN will be calculated
-            for.
-        :return: Dict of CN's for the site n. (e.g. {'O': 4.4, 'F': 2.1})
+        Args:
+            structure: (Structure) a pymatgen Structure
+            n: (int) index of the atom in structure that the CN will be calculated for.
+        Returns:
+            Dict of CN's for the site n. (e.g. {'O': 4.4, 'F': 2.1})
+
         """
         pass
 
 
-class OKeefes(CNBase):
+class OKeeffes(CNBase):
     """
-    O'Keefe's CN's as implemented in pymatgen.
+    O'Keeffe's CN's as implemented in pymatgen.
     Note: We only need to define the compute method using the CNBase class
         that returns a dict object.
         params can be accessed via ._params and passed to actual function.
+    **For Args and Returns see the base class CNBase.**
     """
     def compute(self, structure, n):
         params = self._params
@@ -175,6 +179,7 @@ class OKeefes(CNBase):
 class ECoN(CNBase):
     """
     Effective Coordination Number (ECON) of Hoppe.
+    **For Args and Returns see the base class CNBase.**
     """
     def compute(self, structure, n):
         params = self._params
@@ -182,14 +187,15 @@ class ECoN(CNBase):
         return x.get_cns(**params)
 
 
-class OKeefes_mod(CNBase):
+class OKeeffes_mod(CNBase):
     """
     Modified O'Keefe VoronoiCoordFinder that considers only neighbors
     with at least 50% weight of max(weight).
+    **For Args and Returns see the base class CNBase.**
     """
     def compute(self, structure, n):
         params = self._params
-        x = OKeefes_modified(structure, n)
+        x = OKeeffes_modified(structure, n)
         return x.get_cns(**params)
 
 
@@ -198,6 +204,7 @@ class VoronoiLegacy(CNBase):
     Plain Voronoi coordination numbers (i.e. number of facets of Voronoi polyhedra)
     Should not be used on its own, implemented only for comparison purposes.
     Base line for any Voronoi based CN algorithm.
+    **For Args and Returns see the base class CNBase.**
     """
     def compute(self, structure, n):
         pass
@@ -210,6 +217,7 @@ class BrunnerReciprocal(CNBase):
     Ref:
         G.O. Brunner, A definition of coordination and its relevance in structure types AlB2 and NiAs.
         Acta Crys. A33 (1977) 226.
+    **For Args and Returns see the base class CNBase.**
     """
     def compute(self, structure, n):
         params = self._params
@@ -224,6 +232,7 @@ class BrunnerRelative(CNBase):
     Ref:
         G.O. Brunner, A definition of coordination and its relevance in structure types AlB2 and NiAs.
         Acta Crys. A33 (1977) 226.
+    **For Args and Returns see the base class CNBase.**
     """
     def compute(self, structure, n):
         params = self._params
@@ -238,6 +247,7 @@ class BrunnerReal(CNBase):
     Ref:
         G.O. Brunner, A definition of coordination and its relevance in structure types AlB2 and NiAs.
         Acta Crys. A33 (1977) 226.
+    **For Args and Returns see the base class CNBase.**
     """
     def compute(self, structure, n):
         params = self._params
@@ -273,8 +283,9 @@ def Brunner(structure, n, mode="reciprocal", tol=1.0e-4, radius=8.0):
     return cn
 
 
-class OKeefes_modified(object):
+class OKeeffes_modified(object):
     """
+    Helper class for modified O'Keefe's method.
     Author: S. Bajaj (LBL)
     Modified: M. Aykol (LBL)
     """
@@ -305,6 +316,7 @@ class OKeefes_modified(object):
 class EffectiveCoordFinder_modified(object):
 
     """
+    Helper class for ECoN
     Author: S. Bajaj (LBL)
     Modified: M. Aykol (LBL)
     Finds the average effective coordination number for each cation in a given structure. It
@@ -350,10 +362,10 @@ class EffectiveCoordFinder_modified(object):
 
 def calculate_weighted_avg(bonds):
     """
-    Author: S. Bajaj (LBL)
-    Get the weighted average bond length given by the effective coordination number formula in Hoppe (1979)
-    :param bonds: (list) list of floats that are the bond distances between a cation and its peripheral ions
-    :return: (float) exponential weighted average
+    Args:
+        bonds: (list) list of floats that are the bond distances between a cation and its peripheral ions
+    Returns:
+        (float) exponential weighted average
     """
     minimum_bond = min(bonds)
     weighted_sum = 0.0
@@ -369,7 +381,7 @@ if __name__ == '__main__':
     with MPRester() as mp:
         test_struct = mp.get_structure_by_material_id(test_mpid)
     print get_redf(test_struct)["redf"]
-    cn_methods = [OKeefes, OKeefes_mod, ECoN, BrunnerReal, BrunnerReciprocal, BrunnerRelative]
+    cn_methods = [OKeeffes, OKeeffes_mod, ECoN, BrunnerReal, BrunnerReciprocal, BrunnerRelative]
     for cn_method in cn_methods:
         print cn_method
         r = cn_method()

--- a/matminer/descriptors/structure_features.py
+++ b/matminer/descriptors/structure_features.py
@@ -1,8 +1,11 @@
 from __future__ import division, unicode_literals
-import math
 import numpy as np
+import abc
+import math
 from pymatgen import MPRester
 from pymatgen.analysis.defects import ValenceIonicRadiusEvaluator
+from pymatgen.analysis.structure_analyzer import VoronoiCoordFinder
+from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 __authors__ = 'Anubhav Jain <ajain@lbl.gov>, Saurabh Bajaj <sbajaj@lbl.gov>, ' \
@@ -14,9 +17,9 @@ def get_packing_fraction(s):
         raise ValueError("Disordered structure support not built yet")
     total_rad = 0
     for site in s:
-        total_rad += math.pi * site.specie.atomic_radius**2
+        total_rad += math.pi * site.specie.atomic_radius ** 2
 
-    return total_rad/s.volume
+    return total_rad / s.volume
 
 
 def get_vol_per_site(s):
@@ -47,13 +50,13 @@ def get_rdf(structure, cutoff=20.0, bin_size=0.1):
         neighbors_lst = structure.get_neighbors(site, cutoff)
         for neighbor in neighbors_lst:
             rij = neighbor[1]
-            bin_dist = int(rij/bin_size) * bin_size
+            bin_dist = int(rij / bin_size) * bin_size
             if bin_dist in dist_rdf:
                 dist_rdf[bin_dist] += 1
             else:
                 dist_rdf[bin_dist] = 1
     for bin_idx in dist_rdf:
-        dist_rdf[bin_idx] /= structure.density * 4 * math.pi * (bin_idx**2) * bin_size
+        dist_rdf[bin_idx] /= structure.density * 4 * math.pi * (bin_idx ** 2) * bin_size
     return dist_rdf
 
 
@@ -105,7 +108,8 @@ def get_redf(struct, cutoff=None, dr=0.05):
         a = struct.lattice.matrix[0]
         b = struct.lattice.matrix[1]
         c = struct.lattice.matrix[2]
-        cutoff = max([np.linalg.norm(a+b+c), np.linalg.norm(-a+b+c), np.linalg.norm(a-b+c), np.linalg.norm(a+b-c)])
+        cutoff = max([np.linalg.norm(a + b + c), np.linalg.norm(-a + b + c), np.linalg.norm(a - b + c),
+                      np.linalg.norm(a + b - c)])
 
     nbins = int(cutoff / dr) + 1
     redf_dict = {"distances": np.array([(i + 0.5) * dr for i in range(nbins)]),
@@ -122,8 +126,251 @@ def get_redf(struct, cutoff=None, dr=0.05):
     return redf_dict
 
 
+class CNBase:
+    __metaclass__ = abc.ABCMeta
+    """
+    This is an abstract base class for implementation of CN algorithms. All CN methods
+    must be subclassed from this class, and have a compute method that returns CNs as
+    a dict.
+    """
+
+    def __init__(self, params=None):
+        """
+        :param params: (dict) of parameters to pass to compute method.
+        """
+        self._params = params if params else {}
+        self._cns = {}
+
+    @abc.abstractmethod
+    def compute(self, structure, n):
+        """
+        :param structure: (Structure) a pymatgen Structure
+        :param n: (int) index of the atom in structure that the CN will be calculated
+            for.
+        :return: Dict of CN's for the site n. (e.g. {'O': 4.4, 'F': 2.1})
+        """
+        pass
+
+
+class OKeefes(CNBase):
+    """
+    O'Keefe's CN's as implemented in pymatgen.
+    Note: We only need to define the compute method using the CNBase class
+        that returns a dict object.
+        params can be accessed via ._params and passed to actual function.
+    """
+    def compute(self, structure, n):
+        params = self._params
+        vor = VoronoiCoordFinder(structure, **params)
+        vorp = vor.get_voronoi_polyhedra(n)
+        cdict = {}
+        for i in vorp:
+            if i.species_string not in cdict:
+                cdict[i.species_string] = vorp[i]
+            else:
+                cdict[i.species_string] += vorp[i]
+        return cdict
+
+
+class ECoN(CNBase):
+    """
+    Effective Coordination Number (ECON) of Hoppe.
+    """
+    def compute(self, structure, n):
+        params = self._params
+        x = EffectiveCoordFinder_modified(structure, n)
+        return x.get_cns(**params)
+
+
+class OKeefes_mod(CNBase):
+    """
+    Modified O'Keefe VoronoiCoordFinder that considers only neighbors
+    with at least 50% weight of max(weight).
+    """
+    def compute(self, structure, n):
+        params = self._params
+        x = OKeefes_modified(structure, n)
+        return x.get_cns(**params)
+
+
+class VoronoiLegacy(CNBase):
+    """
+    Plain Voronoi coordination numbers (i.e. number of facets of Voronoi polyhedra)
+    Should not be used on its own, implemented only for comparison purposes.
+    Base line for any Voronoi based CN algorithm.
+    """
+    def compute(self, structure, n):
+        pass
+
+
+class BrunnerReciprocal(CNBase):
+    """
+    Brunner's CN described as counting the atoms that are within the largest gap in
+    differences in reciprocal interatomic distances.
+    Ref:
+        G.O. Brunner, A definition of coordination and its relevance in structure types AlB2 and NiAs.
+        Acta Crys. A33 (1977) 226.
+    """
+    def compute(self, structure, n):
+        params = self._params
+        return Brunner(structure, n, mode="reciprocal", **params)
+
+
+class BrunnerRelative(CNBase):
+    """
+    Brunner's CN described as counting the atoms that are within the largest gap in
+    differences in real space interatomic distances.
+    Note: Might be higly inaccurate in certain cases.
+    Ref:
+        G.O. Brunner, A definition of coordination and its relevance in structure types AlB2 and NiAs.
+        Acta Crys. A33 (1977) 226.
+    """
+    def compute(self, structure, n):
+        params = self._params
+        return Brunner(structure, n, mode="relative", **params)
+
+
+class BrunnerReal(CNBase):
+    """
+    Brunner's CN described as counting the atoms that are within the largest gap in
+    differences in real space interatomic distances.
+    Note: Might be higly inaccurate in certain cases.
+    Ref:
+        G.O. Brunner, A definition of coordination and its relevance in structure types AlB2 and NiAs.
+        Acta Crys. A33 (1977) 226.
+    """
+    def compute(self, structure, n):
+        params = self._params
+        return Brunner(structure, n, mode="real", **params)
+
+
+def Brunner(structure, n, mode="reciprocal", tol=1.0e-4, radius=8.0):
+    """
+    Helper function to compute Brunner's reciprocal gap and realspace gap CN.
+    """
+    nl = structure.get_neighbors(structure.sites[n], radius)
+    ds = [i[-1] for i in nl]
+    ds.sort()
+
+    if mode == "reciprocal":
+        ns = [1.0/ds[i] - 1.0/ds[i+1] for i in range(len(ds) - 1)]
+    elif mode == "relative":
+        ns = [ds[i]/ds[i+1] for i in range(len(ds) - 1)]
+    elif mode == "real":
+        ns = [ds[i] - ds[i+1] for i in range(len(ds) - 1)]
+    else:
+        raise ValueError("Unknown Brunner CN mode.")
+
+    d_max = ds[ ns.index(max(ns)) ]
+    cn = {}
+    for i in nl:
+        if i[-1] < d_max + tol:
+            el = i[0].species_string
+            if el in cn:
+                cn[el] += 1.0
+            else:
+                cn[el] = 1.0
+    return cn
+
+
+class OKeefes_modified(object):
+    """
+    Author: S. Bajaj (LBL)
+    Modified: M. Aykol (LBL)
+    """
+    def __init__(self, structure, n):
+        self._structure = structure
+        self.n = n
+
+    def get_cns(self):
+        siteno = self.n
+        try:
+            vor = VoronoiCoordFinder(self._structure).get_voronoi_polyhedra(siteno)
+            weights = VoronoiCoordFinder(self._structure).get_voronoi_polyhedra(siteno).values()
+        except RuntimeError as e:
+            print e
+
+        coordination = {}
+        max_weight = max(weights)
+        for v in vor:
+            el = v.species_string
+            if vor[v] > 0.50 * max_weight:
+                if el in coordination:
+                    coordination[el]+=1
+                else:
+                    coordination[el] = 1
+        return coordination
+
+
+class EffectiveCoordFinder_modified(object):
+
+    """
+    Author: S. Bajaj (LBL)
+    Modified: M. Aykol (LBL)
+    Finds the average effective coordination number for each cation in a given structure. It
+    finds all cation-centered polyhedral in the structure, calculates the bond weight for each peripheral ion in the
+    polyhedral, and sums up the bond weights to obtain the effective coordination number for each polyhedral. It then
+    averages the effective coordination of all polyhedral with the same cation at the central site.
+    We use the definition from Hoppe (1979) to calculate the effective coordination number of the polyhedrals:
+    Hoppe, R. (1979). Effective coordination numbers (ECoN) and mean Active fictive ionic radii (MEFIR).
+    Z. Kristallogr. , 150, 23-52.
+    ECoN = sum(exp(1-(l_i/l_av)^6)), where l_av = sum(l_i*exp(1-(1_i/l_min)))/sum(exp(1-(1_i/l_min)))
+    """
+
+    def __init__(self, structure, n):
+        self._structure = structure
+        self.n = n
+
+    def get_cns(self, radius=10.0):
+        """
+        Get a specie-centered polyhedra for a structure
+        :param radius: (float) distance in Angstroms for bond cutoff
+        :return: (dict) A dictionary with keys corresponding to different ECoN coordination numbers for site n.
+        """
+        site = self._structure.sites[self.n]
+
+        all_bond_lengths = []
+        neighbor_list = []
+        bond_weights = []
+        for neighbor in self._structure.get_neighbors(site, radius):  # entry = (site, distance)
+            if neighbor[1] < radius:
+                all_bond_lengths.append(neighbor[1])
+                neighbor_list.append(neighbor[0].species_string)
+
+        weighted_avg = calculate_weighted_avg(all_bond_lengths)
+        cns = {}
+        for i in neighbor_list:
+            cns[i]=0.0
+
+        for bond in range(len(all_bond_lengths)):
+            bond_weight = math.exp(1-(all_bond_lengths[bond]/weighted_avg)**6)
+            cns[ neighbor_list[bond]]+=bond_weight
+        return cns
+
+
+def calculate_weighted_avg(bonds):
+    """
+    Author: S. Bajaj (LBL)
+    Get the weighted average bond length given by the effective coordination number formula in Hoppe (1979)
+    :param bonds: (list) list of floats that are the bond distances between a cation and its peripheral ions
+    :return: (float) exponential weighted average
+    """
+    minimum_bond = min(bonds)
+    weighted_sum = 0.0
+    total_sum = 0.0
+    for entry in bonds:
+        weighted_sum += entry*math.exp(1 - (entry/minimum_bond)**6)
+        total_sum += math.exp(1-(entry/minimum_bond)**6)
+    return weighted_sum/total_sum
+
+
 if __name__ == '__main__':
     test_mpid = "mp-2534"
     with MPRester() as mp:
         test_struct = mp.get_structure_by_material_id(test_mpid)
     print get_redf(test_struct)["redf"]
+    cn_methods = [OKeefes, OKeefes_mod, ECoN, BrunnerReal, BrunnerReciprocal, BrunnerRelative]
+    for cn_method in cn_methods:
+        print cn_method
+        r = cn_method()
+        print r.compute(test_struct, 0)

--- a/matminer/descriptors/structure_features.py
+++ b/matminer/descriptors/structure_features.py
@@ -155,7 +155,7 @@ class CNBase:
         pass
 
 
-class OKeeffes(CNBase):
+class CN_OKeeffes(CNBase):
     """
     O'Keeffe's CN's as implemented in pymatgen.
     Note: We only need to define the compute method using the CNBase class
@@ -176,7 +176,7 @@ class OKeeffes(CNBase):
         return cdict
 
 
-class ECoN(CNBase):
+class CN_ECoN(CNBase):
     """
     Effective Coordination Number (ECON) of Hoppe.
     **For Args and Returns see the base class CNBase.**
@@ -187,7 +187,7 @@ class ECoN(CNBase):
         return x.get_cns(**params)
 
 
-class OKeeffes_mod(CNBase):
+class CN_OKeeffes_mod(CNBase):
     """
     Modified O'Keefe VoronoiCoordFinder that considers only neighbors
     with at least 50% weight of max(weight).
@@ -199,7 +199,7 @@ class OKeeffes_mod(CNBase):
         return x.get_cns(**params)
 
 
-class VoronoiLegacy(CNBase):
+class CN_VoronoiLegacy(CNBase):
     """
     Plain Voronoi coordination numbers (i.e. number of facets of Voronoi polyhedra)
     Should not be used on its own, implemented only for comparison purposes.
@@ -210,7 +210,7 @@ class VoronoiLegacy(CNBase):
         pass
 
 
-class BrunnerReciprocal(CNBase):
+class CN_BrunnerReciprocal(CNBase):
     """
     Brunner's CN described as counting the atoms that are within the largest gap in
     differences in reciprocal interatomic distances.
@@ -224,7 +224,7 @@ class BrunnerReciprocal(CNBase):
         return Brunner(structure, n, mode="reciprocal", **params)
 
 
-class BrunnerRelative(CNBase):
+class CN_BrunnerRelative(CNBase):
     """
     Brunner's CN described as counting the atoms that are within the largest gap in
     differences in real space interatomic distances.
@@ -239,7 +239,7 @@ class BrunnerRelative(CNBase):
         return Brunner(structure, n, mode="relative", **params)
 
 
-class BrunnerReal(CNBase):
+class CN_BrunnerReal(CNBase):
     """
     Brunner's CN described as counting the atoms that are within the largest gap in
     differences in real space interatomic distances.
@@ -381,7 +381,7 @@ if __name__ == '__main__':
     with MPRester() as mp:
         test_struct = mp.get_structure_by_material_id(test_mpid)
     print get_redf(test_struct)["redf"]
-    cn_methods = [OKeeffes, OKeeffes_mod, ECoN, BrunnerReal, BrunnerReciprocal, BrunnerRelative]
+    cn_methods = [CN_OKeeffes, CN_OKeeffes_mod, CN_ECoN, CN_BrunnerReal, CN_BrunnerReciprocal, CN_BrunnerRelative]
     for cn_method in cn_methods:
         print cn_method
         r = cn_method()


### PR DESCRIPTION
Adding multiple coordination number algorithms:
- A base CN class ensures consistency among different algorithms
- Each algorithm takes a structure and site index and returns a dictionary of coordinating atoms.

TODO: 
- Post-processing is required to derive more generic descriptors
- Needs some cleanup, especially for helper functions