### PR TITLE
Remove invisible non-ascii character from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Depending on how many of the required dependencies were already installed on you
 .. code-block:: bash
 
     $ # On Mac OS X, install brew if not available
-    $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     $ # Install "freetype" and "pkg-config" using brew (on Mac OS X; for other systems, see http://stackoverflow.com/a/20533455)
     $ brew install freetype
     $ brew install pkg-config


### PR DESCRIPTION
Was causing error `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 5096: ordinal not in range(128)` when trying to install matminer via pip on some systems.

Bit of a weird bug! Character was `\xa0` which is a non-breaking space (aka `&nbsp;` in HTML, probably crept in when copying and pasting the homebrew installation command)