### PR TITLE
Added ability to compute AGNI fingerprints

### DIFF
--- a/matminer/featurizers/atomic_site.py
+++ b/matminer/featurizers/atomic_site.py
@@ -1,0 +1,121 @@
+"""Features that describe the local environment of a single atom
+
+The `featurize` function takes two arguments:
+    strc (Structure): Object representing the structure containing the site of interest
+    site (int): Index of the site to be featurized
+
+We have to use two options because the Site object does not hold a pointer back to its structure. To run
+:code:`featurize_dataframe`, you must pass the column names for both the site and the structure. For example:
+
+.. code:: python
+    f = AGNIFingerprints()
+    f.featurize_dataframe(data, ['site', 'structure'])
+"""
+
+import numpy as np
+
+from .base import BaseFeaturizer
+
+
+class AGNIFingerprints(BaseFeaturizer):
+    """Integral of the product of the radial distribution function and a Gaussian window function.
+
+    Originally used by [Botu *et al*](http://pubs.acs.org/doi/abs/10.1021/acs.jpcc.6b10908) to fit empiricial potentials,
+    these features come in two forms: atomic fingerprints, and direction-resolved fingerprints.
+
+    Atomic fingerprints describe the local environment of an atom and are computed using the function:
+
+    :math:`A_i(\eta) = \sum\limits_{i \ne j} e^{-(\frac{r_{ij}}{\eta})^2} f(r_{ij})`
+
+    where :math:`i` is the index of the atom, :math:`j` is the index of a neighboring atom, :math:`\eta` is a scaling function,
+    :math:`r_{ij}` is the distance between atoms :math:`i` and :math:`j`, and :math:`f(r)` is a cutoff function where
+    :math:`f(r) = 0.5[cos(\frac{\pi r_{ij}}{R_c}) + 1]` if :math:`r < R_c:math:` and 0 otherwise.
+
+    The direction-resolved fingerprints are computed using
+
+    :math:`V_i^k(\eta) = \sum\limits_{i \ne j} \frac{r_{ij}^k}{r_{ij}} e^{-(\frac{r_{ij}}{\eta})^2} f(r_{ij})`
+
+    where :math:`r_{ij}^k` is the :math:`k^{th}` component of :math:`\bold{r}_i - \bold{r}_j`.
+
+    Parameters:
+            directions (iterable): List of directions for the fingerprints. Can be `none`, 'x', 'y', or 'z'
+            etas (iterable of floats): List of which window widths to compute
+            cutoff (float): Cutoff distance
+
+    TODO: Differentiate between different atom types (maybe as another class)
+    """
+
+    def __init__(self, directions=(None, 'x', 'y', 'z'), etas=np.logspace(np.log10(0.8), np.log10(16), 8),
+                 cutoff=8):
+        self.directions = directions
+        self.etas = etas
+        self.cutoff = cutoff
+
+    @property
+    def directions(self):
+        return self.__directions
+
+    @directions.setter
+    def directions(self, dirs):
+        for d in dirs:
+            if d not in [None, 'x', 'y', 'z']:
+                raise Exception('Direction not `None`, x, y, or z: z')
+        self.__directions = dirs
+
+    def featurize(self, strc, site):
+        # Get all neighbors of this site
+        my_site = strc[site]
+        sites, dists = zip(*strc.get_neighbors(my_site, self.cutoff))
+
+        # Convert dists to a ndarray
+        dists = np.array(dists)
+
+        # If one of the features is direction-dependent, compute the :math:`(r_i - r_j) / r_{ij}`
+        if any([x in self.directions for x in ['x', 'y', 'z']]):
+            disps = np.array([my_site.coords - s.coords for s in sites]) / dists[:, np.newaxis]
+
+        # Compute the cutoff function
+        cutoff_func = 0.5 * (np.cos(np.pi * dists / self.cutoff) + 1)
+
+        # Compute "e^(r/eta) * cutoff_func" for each eta
+        windowed = np.zeros((len(dists), len(self.etas)))
+        for i, eta in enumerate(self.etas):
+            windowed[:, i] = np.multiply(np.exp(-1 * np.power(np.divide(dists, eta), 2)), cutoff_func)
+
+        # Compute the fingerprints
+        output = []
+        for d in self.directions:
+            if d is None:
+                output.append(np.sum(windowed, axis=0))
+            else:
+                if d is 'x':
+                    proj = [1., 0., 0.]
+                elif d is 'y':
+                    proj = [0., 1., 0.]
+                elif d is 'z':
+                    proj = [0., 0., 1.]
+                else:
+                    raise Exception('Unrecognized direction')
+                output.append(np.sum(windowed * np.dot(disps, proj)[:, np.newaxis], axis=0))
+
+        # Return the results
+        return np.hstack(output)
+
+    def feature_labels(self):
+        labels = []
+        for d in self.directions:
+            for e in self.etas:
+                if d is None:
+                    labels.append('AGNI eta=%.2e' % e)
+                else:
+                    labels.append('AGNI dir=%s eta=%.2e' % (d, e))
+        return labels
+
+    def citations(self):
+        return "@article{Botu2015, author = {Botu, Venkatesh and Ramprasad, Rampi},doi = {10.1002/qua.24836}," \
+               "journal = {International Journal of Quantum Chemistry},number = {16},pages = {1074--1083}," \
+               "title = {{Adaptive machine learning framework to accelerate ab initio molecular dynamics}}," \
+               "volume = {115},year = {2015}}"
+
+    def implementors(self):
+        return ['Logan Ward']

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -1,4 +1,5 @@
 import numpy as np
+from six import string_types
 
 class BaseFeaturizer(object):
     """Abstract class to calculate attributes for compounds"""
@@ -9,24 +10,30 @@ class BaseFeaturizer(object):
         
         Args: 
             df (Pandas dataframe): Dataframe containing input data
-            col_id (string): column label containing objects to featurize
+            col_id (str or list of str): column label containing objects to featurize. Can be multiple labels, if the featurize
+                function requires multiple inputs
 
         Returns:
             updated Dataframe
         """
 
+        # If only one column and user provided a string, put it inside a list
+        if isinstance(col_id, string_types):
+            col_id = [col_id]
+
+        # Compute the features
         features = []
         x_list = df[col_id]
-        for x in x_list:
-            features.append(self.featurize(x))
-        
-        features = np.array(features)
+        for x in x_list.values:
+            features.append(self.featurize(*x))
 
+        # Add features to dataframe
+        features = np.array(features)
         labels = self.feature_labels()
         df = df.assign(**dict(zip(labels, features.T)))
         return df
-    
-    def featurize(self, x):
+
+    def featurize(self, *x):
         """
         Main featurizer function. Only defined in feature subclasses.
 

--- a/matminer/featurizers/tests/test_atomic_site.py
+++ b/matminer/featurizers/tests/test_atomic_site.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pandas as pd
+from pymatgen import Structure, Lattice
+from pymatgen.util.testing import PymatgenTest
+
+from matminer.featurizers.atomic_site import AGNIFingerprints
+
+
+class AGNIFingerprintTests(PymatgenTest):
+    def setUp(self):
+        self.sc = Structure(
+            Lattice([[3.52, 0, 0], [0, 3.52, 0], [0, 0, 3.52]]),
+            ["Al", ],
+            [[0, 0, 0]],
+            validate_proximity=False, to_unit_cell=False,
+            coords_are_cartesian=False)
+        self.cscl = Structure(
+            Lattice([[4.209, 0, 0], [0, 4.209, 0], [0, 0, 4.209]]),
+            ["Cl1-", "Cs1+"], [[0.45, 0.5, 0.5], [0, 0, 0]],
+            validate_proximity=False, to_unit_cell=False,
+            coords_are_cartesian=False)
+
+    def test_simple_cubic(self):
+        """Test with an easy structure"""
+
+        # Make sure direction-dependent fingerprints are zero
+        agni = AGNIFingerprints(directions=['x', 'y', 'z'])
+
+        features = agni.featurize(self.sc, 0)
+        self.assertEquals(8 * 3, len(features))
+        self.assertEquals(8 * 3, len(set(agni.feature_labels())))
+        self.assertArrayAlmostEqual([0, ] * 24, features)
+
+        # Compute the "atomic fingerprints"
+        agni.directions = [None]
+        agni.cutoff = 3.75  # To only get 6 neighbors to deal with
+
+        features = agni.featurize(self.sc, 0)
+        self.assertEquals(8, len(features))
+        self.assertEquals(8, len(set(agni.feature_labels())))
+
+        self.assertEquals(0.8, agni.etas[0])
+        self.assertAlmostEquals(6 * np.exp(-(3.52 / 0.8) ** 2) * 0.5 * (np.cos(np.pi * 3.52 / 3.75) + 1), features[0])
+        self.assertAlmostEquals(6 * np.exp(-(3.52 / 16) ** 2) * 0.5 * (np.cos(np.pi * 3.52 / 3.75) + 1), features[-1])
+
+    def test_off_center_cscl(self):
+        agni = AGNIFingerprints(directions=[None, 'x', 'y', 'z'], cutoff=4)
+
+        # Compute the features on both sites
+        site1 = agni.featurize(self.cscl, 0)
+        site2 = agni.featurize(self.cscl, 1)
+
+        # The atomic attributes should be equal
+        self.assertArrayAlmostEqual(site1[:8], site2[:8])
+
+        # The direction-dependent ones should be equal and opposite in sign
+        self.assertArrayAlmostEqual(-1 * site1[8:], site2[8:])
+
+        # Make sure the site-ones are as expected.
+        right_dist = 4.209 * np.sqrt(0.45 ** 2 + 2 * 0.5 ** 2)
+        right_xdist = 4.209 * 0.45
+        left_dist = 4.209 * np.sqrt(0.55 ** 2 + 2 * 0.5 ** 2)
+        left_xdist = 4.209 * 0.55
+        self.assertAlmostEquals(4 * (
+            right_xdist / right_dist * np.exp(-(right_dist / 0.8) ** 2) * 0.5 * (np.cos(np.pi * right_dist / 4) + 1) -
+            left_xdist / left_dist * np.exp(-(left_dist / 0.8) ** 2) * 0.5 * (np.cos(np.pi * left_dist / 4) + 1)),
+                                site1[8])
+
+    def test_dataframe(self):
+        data = pd.DataFrame({'strc': [self.cscl, self.cscl, self.sc], 'site': [0, 1, 0]})
+
+        agni = AGNIFingerprints()
+        agni.featurize_dataframe(data, ['strc', 'site'])


### PR DESCRIPTION
Implemented the AGNI fingerprints developed by [Botu *et al*](http://doi.wiley.com/10.1002/qua.24836).

The bigger thing that should be reviewed is changes to `BaseFeaturizer`. I needed to be able to pass both a structure and site to the new featurizer, so I modified the `featurizer`  method to take a variable number of arguments and the `featurize_dataframe` operation to allow you to generate features based on more than one column. I made sure to do this in a way that did not require modifying any of the other featurizer classes. 

What I'm unsure of is whether this additional flexibility is helpful or would open the door to too much inconsistency between the featurizers. Any thoughts?