### PR TITLE
SiteOrderParameters class and n_numerical_modes updated

### DIFF
--- a/matminer/featurizers/stats.py
+++ b/matminer/featurizers/stats.py
@@ -134,18 +134,21 @@ class PropertyStats(object):
     @staticmethod
     def n_numerical_modes(data_lst, n, dl=0.1):
         """
-        Determines the n first modes of a data set that are obtained with
-        a finite bin size for the underlying frequency distribution.
+        Returns the n first modes of a data set that are obtained with
+            a finite bin size for the underlying frequency distribution.
         Args:
-            data_lst (list of floats): data values.
+            data_lst ([float]): data values.
             n (integer): number of most frequent elements to be determined.
             dl (float): bin size of underlying (coarsened) distribution.
-        Returns: 
-            modes (list of float): first n most frequent elements.
+        Returns:
+            ([float]): first n most frequent entries (or nan if not found).
         """
+        if len(set(data_lst)) == 1:
+            return [data_lst[0]] + [float('NaN') for _ in range(n-1)]
         hist, bins = np.histogram(data_lst, bins=np.arange(
                 min(data_lst), max(data_lst), dl), density=False)
-        return bins[np.argsort(hist)[-n:]][::-1]
+        modes = list(bins[np.argsort(hist)[-n:]][::-1])
+        return modes + [float('NaN') for _ in range(n-len(modes))]
 
     @staticmethod
     def holder_mean(data_lst, weights=None, power=1):

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -820,7 +820,7 @@ class SitesOrderParameters(BaseFeaturizer):
 
 def get_order_parameter_stats(
         struct, pneighs=None, convert_none_to_zero=True, delta_op=0.01,
-        ignore_op_types=None):
+        ignore_op_types=None, bond_angles=None):
     """
     Determine the order parameter statistics accumulated across all sites
     in Structure object struct using the get_order_parameters function.
@@ -847,11 +847,14 @@ def get_order_parameter_stats(
     """
     opstats = {}
     optypes = ["cn", "lin"]
-    for i in range(5, 180, 5):
+    bond_angles = bond_angles or [45, 90, 135]
+    for i in bond_angles:
         optypes.append("bent{}".format(i))
-    for t in ["tet", "oct", "bcc", "q2", "q4", "q6", "reg_tri", "sq", "sq_pyr", "tri_bipyr"]:
+    for t in ["tet", "oct", "bcc", "q2", "q4", "q6",
+              "reg_tri", "sq", "sq_pyr", "tri_bipyr"]:
         optypes.append(t)
-    opvals = SitesOrderParameters(pneighs=pneighs).featurize(struct)
+    opvals = SitesOrderParameters(pneighs=pneighs, bond_angles=bond_angles).\
+            featurize(struct)
     for i, opstype in enumerate(opvals):
         if ignore_op_types is not None:
             if optypes[i] in ignore_op_types or \

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -53,6 +53,7 @@ class StructureFeaturesTest(PymatgenTest):
             [[0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]],
             validate_proximity=False, to_unit_cell=False,
             coords_are_cartesian=False, site_properties=None)
+        self.bond_angles = range(5, 180, 5)
 
     def test_density_features(self):
         df = DensityFeatures()
@@ -262,28 +263,36 @@ class StructureFeaturesTest(PymatgenTest):
     #        self.cscl, 0)), 8)
 
     def test_get_order_parameters(self):
-        opvals = SitesOrderParameters().featurize(self.diamond)
+        opvals = SitesOrderParameters(
+                bond_angles=self.bond_angles).featurize(self.diamond)
         self.assertAlmostEqual(int(opvals[37][0] * 1000), 999)
         self.assertAlmostEqual(int(opvals[37][1] * 1000), 999)
-        opvals = SitesOrderParameters().featurize(self.nacl)
+        opvals = SitesOrderParameters(
+            bond_angles=self.bond_angles
+        ).featurize(self.nacl)
         self.assertAlmostEqual(int(opvals[38][0] * 1000), 999)
         self.assertAlmostEqual(int(opvals[38][1] * 1000), 999)
-        opvals = SitesOrderParameters().featurize(self.cscl)
+        opvals = SitesOrderParameters(
+            bond_angles=self.bond_angles
+        ).featurize(self.cscl)
         self.assertAlmostEqual(int(opvals[39][0] * 1000), 975)
         self.assertAlmostEqual(int(opvals[39][1] * 1000), 975)
 
     def test_get_order_parameter_stats(self):
-        opstats = get_order_parameter_stats(self.diamond)
+        opstats = get_order_parameter_stats(self.diamond,
+                                            bond_angles=self.bond_angles)
         self.assertAlmostEqual(int(opstats["tet"]["min"] * 1000), 999)
         self.assertAlmostEqual(int(opstats["tet"]["max"] * 1000), 999)
         self.assertAlmostEqual(int(opstats["tet"]["mean"] * 1000), 999)
         self.assertAlmostEqual(int(opstats["tet"]["std"] * 1000), 0)
-        opstats = get_order_parameter_stats(self.nacl)
+        opstats = get_order_parameter_stats(self.nacl,
+                                            bond_angles=self.bond_angles)
         self.assertAlmostEqual(int(opstats["oct"]["min"] * 1000), 999)
         self.assertAlmostEqual(int(opstats["oct"]["max"] * 1000), 999)
         self.assertAlmostEqual(int(opstats["oct"]["mean"] * 1000), 999)
         self.assertAlmostEqual(int(opstats["oct"]["std"] * 1000), 0)
-        opstats = get_order_parameter_stats(self.cscl)
+        opstats = get_order_parameter_stats(self.cscl,
+                                            bond_angles=self.bond_angles)
         self.assertAlmostEqual(int(opstats["bcc"]["min"] * 1000), 975)
         self.assertAlmostEqual(int(opstats["bcc"]["max"] * 1000), 975)
         self.assertAlmostEqual(int(opstats["bcc"]["mean"] * 1000), 975)

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -277,6 +277,7 @@ class StructureFeaturesTest(PymatgenTest):
         ).featurize(self.cscl)
         self.assertAlmostEqual(int(opvals[39][0] * 1000), 975)
         self.assertAlmostEqual(int(opvals[39][1] * 1000), 975)
+        #TODO-AF: add test_order_parameters for when stats not None
 
     def test_get_order_parameter_stats(self):
         opstats = get_order_parameter_stats(self.diamond,


### PR DESCRIPTION
modified SitesOrderParameters to conveniently work with a DataFrame (similar to ElementProperty for example) taking in features, and stats as inputs. Note that SiteOrderParameters works just like before if stats is None (i.e. it would return calculated order parameters for each site in a list). It is also backwards-compatible as none of the arguments (including data_source) is required.


In the process, I had to also change PropertyStats.n_numerical_modes method as it had a couple of issues:

1) it was returning error for an example input of [6.0, 6.0] for which clearly the first mode should be 6.0

2) It wasn't handling the cases where the nth mode doesn't exist and would return lists with unexpected lengths: I added conditions so now it returns nan for each mode that is not found.