### PR TITLE
Bug: featurize_dataframe fails when only one feature

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -29,6 +29,12 @@ class BaseFeaturizer(object):
 
         # Add features to dataframe
         features = np.array(features)
+        
+        #  Special case: For single attribute, add an axis
+        if len(features.shape) == 1:
+            features = features[:, np.newaxis]
+            
+        # Add features to dataframe
         labels = self.feature_labels()
         df = df.assign(**dict(zip(labels, features.T)))
         return df

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -1,0 +1,44 @@
+from __future__ import unicode_literals, division, print_function
+
+import unittest
+import pandas as pd
+
+from pymatgen.util.testing import PymatgenTest
+
+from matminer.featurizers.base import BaseFeaturizer
+
+
+class SingleFeaturizer(BaseFeaturizer):
+    def feature_labels(self):
+        return ['y']
+       
+    def featurize(self, x):
+        return x + 1
+        
+class MultipleFeaturizer(BaseFeaturizer):
+    def feature_labels(self):
+        return ['y', 'z']
+       
+    def featurize(self, x):
+        return [x - 1, x + 2]
+
+class TestBaseClass(PymatgenTest):
+    
+    def setUp(self):
+        self.single = SingleFeaturizer()
+        self.multi = MultipleFeaturizer()
+        
+    def test_dataframe(self):
+        data = pd.DataFrame({'x': [1,2,3]})
+        data = self.single.featurize_dataframe(data, 'x')
+        self.assertArrayAlmostEqual(data['y'], [2,3,4])
+        
+        data = self.multi.featurize_dataframe(data, 'x')
+        self.assertArrayAlmostEqual(data['y'], [0,1,2])
+        self.assertArrayAlmostEqual(data['z'], [3,4,5])
+        
+        
+        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Turns out the `featurize_dataframe` operation fails when the class only generates a single feature. 

The problem was with how numpy.array works. If there is more than 1 feature, this line in the code creates a 2D array. If there is only 1 feature, it creates a 1D array. I fixed it by adding code to manually change 1D->2D. (Note: the ndmin kwarg of np.array puts the new dimension on the wrong side)

Also added test case that fails before this fix was added, and should now pass