### PR TITLE
Fixed constructor for AGNIFingerprints

### DIFF
--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -53,7 +53,9 @@ class AGNIFingerprints(BaseFeaturizer):
     def __init__(self, directions=(None, 'x', 'y', 'z'), etas=None,
                  cutoff=8):
         self.directions = directions
-        self.etas = etas or np.logspace(np.log10(0.8), np.log10(16), 8)
+        self.etas = etas
+        if self.etas is None:
+            self.etas = np.logspace(np.log10(0.8), np.log10(16), 8)
         self.cutoff = cutoff
 
     @property

--- a/matminer/featurizers/tests/test_site.py
+++ b/matminer/featurizers/tests/test_site.py
@@ -29,8 +29,8 @@ class FingerprintTests(PymatgenTest):
         agni = AGNIFingerprints(directions=['x', 'y', 'z'])
 
         features = agni.featurize(self.sc, 0)
-        self.assertEquals(8 * 3, len(features))
-        self.assertEquals(8 * 3, len(set(agni.feature_labels())))
+        self.assertEqual(8 * 3, len(features))
+        self.assertEqual(8 * 3, len(set(agni.feature_labels())))
         self.assertArrayAlmostEqual([0, ] * 24, features)
 
         # Compute the "atomic fingerprints"
@@ -38,12 +38,17 @@ class FingerprintTests(PymatgenTest):
         agni.cutoff = 3.75  # To only get 6 neighbors to deal with
 
         features = agni.featurize(self.sc, 0)
-        self.assertEquals(8, len(features))
-        self.assertEquals(8, len(set(agni.feature_labels())))
+        self.assertEqual(8, len(features))
+        self.assertEqual(8, len(set(agni.feature_labels())))
 
-        self.assertEquals(0.8, agni.etas[0])
+        self.assertEqual(0.8, agni.etas[0])
         self.assertAlmostEqual(6 * np.exp(-(3.52 / 0.8) ** 2) * 0.5 * (np.cos(np.pi * 3.52 / 3.75) + 1), features[0])
         self.assertAlmostEqual(6 * np.exp(-(3.52 / 16) ** 2) * 0.5 * (np.cos(np.pi * 3.52 / 3.75) + 1), features[-1])
+        
+        # Test that passing etas to constructor works
+        new_etas = np.logspace(-4, 2, 6)
+        agni = AGNIFingerprints(directions=['x', 'y', 'z'], etas=new_etas)
+        self.assertArrayAlmostEqual(new_etas, agni.etas)
 
     def test_off_center_cscl(self):
         agni = AGNIFingerprints(directions=[None, 'x', 'y', 'z'], cutoff=4)


### PR DESCRIPTION
Problem with using 'x or y' syntax for setting self.etas. If the user passes a numpy array, this results in a `ValueError` about the truth value of 'or' being undefined for arrays. I suspect that this is because
numpy arrays overload the function __or__. Either way, this fix changes it.

I also added a test case that fails with the old version and passes with this new one.