### PR TITLE
add the possibility of including the energy of a given list of k-points normalized to the CBM/VBM as features.

### DIFF
--- a/matminer/featurizers/bandstructure.py
+++ b/matminer/featurizers/bandstructure.py
@@ -138,7 +138,7 @@ class BandFeaturizer(BaseFeaturizer):
                 is_gap_direct (0.0|1.0): whether the band gap is direct or not
                 direct_gap (eV): the minimum direct distance of the last
                     valence band and the first conduction band
-                p_ex1_norm (flaot): k-space distance between Gamma point
+                p_ex1_norm (float): k-space distance between Gamma point
                     and k-point of VBM
                 n_ex1_norm (float): k-space distance between Gamma point
                     and k-point of CBM

--- a/matminer/featurizers/bandstructure.py
+++ b/matminer/featurizers/bandstructure.py
@@ -190,7 +190,7 @@ class BandFeaturizer(BaseFeaturizer):
                 self.feat['{}_ex1_degen'] = float('NaN')
         if self.weight > 1:
             self.apply_weights(self.weight)
-        return self.feat.values()
+        return list(self.feat.values())
 
     def apply_weights(self, weight):
         """
@@ -206,7 +206,7 @@ class BandFeaturizer(BaseFeaturizer):
             self.feat[key] *= max(1, weight/2.)
 
     def feature_labels(self):
-        return self.feat.keys()
+        return list(self.feat.keys())
 
     @staticmethod
     def get_bindex_bspin(extremum, is_cbm):

--- a/matminer/featurizers/bandstructure.py
+++ b/matminer/featurizers/bandstructure.py
@@ -110,13 +110,13 @@ class BandFeaturizer(BaseFeaturizer):
     Args:
         kpoints ([1x3 numpy array]): list of fractional coordinates of
                 k-points at which energy is extracted.
-            method (str): the method for finding or interpolating for energy at
-                given kpoints. It does nothing if kpoints is None.
-                options are:
-                    'nearest': the energy of the nearest available k-point to
-                        the input k-point is returned.
-                    'linear': the result of linear interpolation is returned
-                    see the documentation for scipy.interpolate.griddata
+        find_method (str): the method for finding or interpolating for energy
+            at given kpoints. It does nothing if kpoints is None.
+            options are:
+                'nearest': the energy of the nearest available k-point to
+                    the input k-point is returned.
+                'linear': the result of linear interpolation is returned
+                see the documentation for scipy.interpolate.griddata
     """
 
     def __init__(self, kpoints=None, find_method='nearest'):

--- a/matminer/featurizers/bandstructure.py
+++ b/matminer/featurizers/bandstructure.py
@@ -109,12 +109,10 @@ class BandFeaturizer(BaseFeaturizer):
     Featurizes a pymatgen band structure object.
     """
 
-    def __init__(self, kpoints=None, atol=0.01, include_symeqks=False,
-                 weight=1):
+    def __init__(self, kpoints=None, atol=0.01, include_symeqks=False):
         self.atol = atol
         self.include_symeqks = include_symeqks
         self.kpoints = kpoints
-        self.weight = weight
 
     def featurize(self, bs):
         """
@@ -129,8 +127,6 @@ class BandFeaturizer(BaseFeaturizer):
             include_symeqks (bool): if True, when looking for energy of the
                 bands at given kpoints, symmetrically equivalent kpoints are
                 also considered (recommended to keep False for speed)
-            weight (int >= 1): if larger than 1, some features are multiplied
-                by it to emphasize their importance in the features vector.
         Returns:
              ([float]): a list of band structure features. If not bs.structure,
                 features that require the structure will be returned as NaN.
@@ -198,22 +194,9 @@ class BandFeaturizer(BaseFeaturizer):
                         bs.get_kpoint_degeneracy(cvd[tp]['k'])
             else:
                 self.feat['{}_ex1_degen'] = float('NaN')
-        if self.weight > 1:
-            self.apply_weights(self.weight)
         return list(self.feat.values())
 
-    def apply_weights(self, weight):
-        """
-        multiply some features by weight or a fraction of weight to emphasize
-            more on their importance (e.g. norm(kpoint) of the CBM/VBM)
-        Args:
-            weight (float): base weight; no effect if weight==1
-        Returns (dict): features
-        """
-        for key in ['is_gap_direct', 'p_ex1_norm', 'n_ex1_norm']:
-            self.feat[key] *= weight
-        for key in ['band_gap', 'direct_gap']:
-            self.feat[key] *= max(1, weight/2.)
+
 
     def feature_labels(self):
         return list(self.feat.keys())

--- a/matminer/featurizers/bandstructure.py
+++ b/matminer/featurizers/bandstructure.py
@@ -184,7 +184,7 @@ class BandFeaturizer(BaseFeaturizer):
         if self.kpoints:
             fits = {tp: griddata(points=np.array(bs_kpts),
                         values=cvd[tp]['Es']-cvd[tp]['energy'],
-                        xi=self.kpoints, method='linear') for tp in ['p', 'n']}
+                        xi=self.kpoints, method='nearest') for tp in ['p', 'n']}
             for tp in ['p', 'n']:
                 for ik, k in enumerate(self.kpoints):
                     k_name = '{}_{};{};{}_en'.format(tp, k[0], k[1], k[2])

--- a/matminer/featurizers/tests/test_bandstructure.py
+++ b/matminer/featurizers/tests/test_bandstructure.py
@@ -11,6 +11,7 @@ from pymatgen import Structure
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine, \
     BandStructure
 from pymatgen.electronic_structure.dos import CompleteDos
+from pymatgen.symmetry.bandstructure import HighSymmKpath
 from pymatgen.util.testing import PymatgenTest
 
 test_dir = os.path.join(os.path.dirname(__file__))
@@ -28,7 +29,7 @@ class BandstructureFeaturesTest(PymatgenTest):
         with open(os.path.join(test_dir, 'si_bandstructure_uniform.json'),'r') as bsh:
             si_bs_uniform = BandStructure.from_dict(json.load(bsh))
         si_bs_uniform.structure = si_str
-
+        self.si_kpts = HighSymmKpath(si_str).kpath['kpoints'].values()
         self.df = pd.DataFrame({'bs_line': [si_bs_line], 'bs_uniform': [si_bs_uniform]})
 
     def test_BranchPointEnergy(self):
@@ -40,7 +41,8 @@ class BandstructureFeaturesTest(PymatgenTest):
         self.assertAlmostEqual(df_bpe['vbm_absolute'][0], -0.114, 3)
 
     def test_BandFeaturizer(self):
-        df_bf = BandFeaturizer().featurize_dataframe(self.df, col_id='bs_line')
+        bs_featurizer = BandFeaturizer(self.si_kpts)
+        df_bf = bs_featurizer.featurize_dataframe(self.df, col_id='bs_line')
         self.assertAlmostEqual(df_bf['band_gap'][0], 0.612, 3)
         self.assertAlmostEqual(df_bf['direct_gap'][0], 2.557, 3)
         self.assertAlmostEqual(df_bf['n_ex1_norm'][0], 0.58413, 5)
@@ -48,6 +50,15 @@ class BandstructureFeaturesTest(PymatgenTest):
         self.assertEqual(df_bf['is_gap_direct'][0], False)
         self.assertEqual(df_bf['n_ex1_degen'][0], 6)
         self.assertEqual(df_bf['p_ex1_degen'][0], 1)
+        self.assertEqual(df_bf['p_0.0;0.0;0.0_en'][0], 0.0)
+        self.assertEqual(df_bf['p_0.0;0.0;0.0_en'][0], 0.0)
+        self.assertAlmostEqual(df_bf['p_0.375;0.375;0.75_en'][0], -2.3745, 4)
+        self.assertAlmostEqual(df_bf['p_0.5;0.0;0.5_en'][0], -2.7928, 4)
+        self.assertAlmostEqual(df_bf['p_0.625;0.25;0.625_en'][0], -2.3745, 4)
+        self.assertAlmostEqual(df_bf['p_0.5;0.5;0.5_en'][0], -1.1779, 4)
+        self.assertAlmostEqual(df_bf['n_0.0;0.0;0.0_en'][0], 1.945, 4)
+        self.assertAlmostEqual(df_bf['n_0.5;0.25;0.75_en'][0], 3.6587, 4)
+        self.assertAlmostEqual(df_bf['n_0.5;0.5;0.5_en'][0], 0.8534, 4)
 
 class DOSFeaturesTest(PymatgenTest):
 
@@ -57,9 +68,7 @@ class DOSFeaturesTest(PymatgenTest):
         self.df = pd.DataFrame({'dos': [si_dos]})
 
     def test_DOSFeaturizer(self):
-        df_df = DOSFeaturizer().featurize_dataframe(self.df,
-                                                    col_id=['dos'])
-
+        df_df = DOSFeaturizer().featurize_dataframe(self.df, col_id=['dos'])
         self.assertAlmostEqual(df_df['cbm_percents'][0][0], 0.258, 3)
         self.assertAlmostEqual(df_df['cbm_locations'][0], [[0.0, 0.0, 0.0]])
         self.assertEqual(df_df['cbm_species'][0], ['Si'])

--- a/matminer/featurizers/tests/test_bandstructure.py
+++ b/matminer/featurizers/tests/test_bandstructure.py
@@ -29,7 +29,7 @@ class BandstructureFeaturesTest(PymatgenTest):
         with open(os.path.join(test_dir, 'si_bandstructure_uniform.json'),'r') as bsh:
             si_bs_uniform = BandStructure.from_dict(json.load(bsh))
         si_bs_uniform.structure = si_str
-        self.si_kpts = HighSymmKpath(si_str).kpath['kpoints'].values()
+        self.si_kpts = list(HighSymmKpath(si_str).kpath['kpoints'].values())
         self.df = pd.DataFrame({'bs_line': [si_bs_line], 'bs_uniform': [si_bs_uniform]})
 
     def test_BranchPointEnergy(self):


### PR DESCRIPTION
1) add normalized energy at given k-points as features (the fractional coordinates of the k-points should be given by the user, if any 
2) restructure featurize to make it more compact
3) store features in a dict to make it easier to implement apply_weight method; apply_weight is not run by default (if weight==1); however. I found it useful in identifying band structures that are more similar to each other based on the Euclidean distance of BS feature vector.