### PR TITLE
Improve featurize dataframe

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -7,7 +7,7 @@ from six import string_types
 class BaseFeaturizer(object):
     """Abstract class to calculate attributes for compounds"""
 
-    def featurize_dataframe(self, df, col_id, ignore_errors=False):
+    def featurize_dataframe(self, df, col_id, ignore_errors=False, inplace=True):
         """
         Compute features for all entries contained in input dataframe
         
@@ -19,6 +19,7 @@ class BaseFeaturizer(object):
             ignore_errors (bool): Returns NaN for dataframe rows where
                 exceptions are thrown if True. If False, exceptions
                 are thrown as normal.
+            inplace (bool): Whether to add new columns to input dataframe (df)
 
         Returns:
             updated Dataframe
@@ -48,7 +49,12 @@ class BaseFeaturizer(object):
         new_cols = dict(zip(labels, [pd.Series(x) for x in zip(*features)]))
 
         # Update the dataframe
-        return df.assign(**new_cols)
+        if inplace:
+            for key, value in new_cols.items():
+                df[key] = value
+            return df
+        else:
+            return df.assign(**new_cols)
 
     def featurize(self, *x):
         """

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-import numpy as np
+import pandas as pd
 from six import string_types
 
 
@@ -41,23 +41,14 @@ class BaseFeaturizer(object):
                 else:
                     raise
 
-        # Add features to dataframe
-        features = np.array(features)
-
-        #  Special case: For single attribute, add an axis
-        if len(features.shape) == 1:
-            features = features[:, np.newaxis]
-
-        # TODO: @JFChen3 @WardLT - is df.join() more efficient than df.assign? -computron
-        # Add features to dataframe
+        # Generate the feature labels
         labels = self.feature_labels()
-        df = df.assign(**dict(zip(labels, features.T)))
-        for col in df:
-            try:
-                df[col] = df[col].astype(float)
-            except:
-                pass
-        return df
+
+        # Create dataframe with the new features
+        new_cols = dict(zip(labels, [pd.Series(x) for x in zip(*features)]))
+
+        # Update the dataframe
+        return df.assign(**new_cols)
 
     def featurize(self, *x):
         """

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -52,6 +52,16 @@ class TestBaseClass(PymatgenTest):
         """Test the ability to add features that are matrices to a dataframe"""
         data = pd.DataFrame({'x': [1, 2, 3]})
         data = self.matrix.featurize_dataframe(data, 'x')
+        self.assertArrayAlmostEqual(np.eye(2, 2), data['representation'][0])
+
+    def test_inplace(self):
+        data = pd.DataFrame({'x': [1, 2, 3]})
+
+        self.single.featurize_dataframe(data, 'x', inplace=False)
+        self.assertNotIn('y', data.columns)
+
+        self.single.featurize_dataframe(data, 'x', inplace=True)
+        self.assertIn('y', data)
 
 
 if __name__ == '__main__':

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals, division, print_function
 
 import unittest
 import pandas as pd
+import numpy as np
 
 from pymatgen.util.testing import PymatgenTest
 
@@ -11,34 +12,47 @@ from matminer.featurizers.base import BaseFeaturizer
 class SingleFeaturizer(BaseFeaturizer):
     def feature_labels(self):
         return ['y']
-       
+
     def featurize(self, x):
-        return x + 1
-        
+        return [x + 1]
+
+
 class MultipleFeaturizer(BaseFeaturizer):
     def feature_labels(self):
         return ['y', 'z']
-       
+
     def featurize(self, x):
         return [x - 1, x + 2]
 
+
+class MatrixFeaturizer(BaseFeaturizer):
+    def feature_labels(self):
+        return ['representation']
+
+    def featurize(self, *x):
+        return [np.eye(2, 2)]
+
+
 class TestBaseClass(PymatgenTest):
-    
     def setUp(self):
         self.single = SingleFeaturizer()
         self.multi = MultipleFeaturizer()
-        
+        self.matrix = MatrixFeaturizer()
+
     def test_dataframe(self):
-        data = pd.DataFrame({'x': [1,2,3]})
+        data = pd.DataFrame({'x': [1, 2, 3]})
         data = self.single.featurize_dataframe(data, 'x')
-        self.assertArrayAlmostEqual(data['y'], [2,3,4])
-        
+        self.assertArrayAlmostEqual(data['y'], [2, 3, 4])
+
         data = self.multi.featurize_dataframe(data, 'x')
-        self.assertArrayAlmostEqual(data['y'], [0,1,2])
-        self.assertArrayAlmostEqual(data['z'], [3,4,5])
-        
-        
-        
+        self.assertArrayAlmostEqual(data['y'], [0, 1, 2])
+        self.assertArrayAlmostEqual(data['z'], [3, 4, 5])
+
+    def test_matrix(self):
+        """Test the ability to add features that are matrices to a dataframe"""
+        data = pd.DataFrame({'x': [1, 2, 3]})
+        data = self.matrix.featurize_dataframe(data, 'x')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Minor changes to `featurize_dataframe`:

1. Allow features that are matrices (fixes #100)
1. Prevent copying the dataframe by default. The `assign` operation creates a copy of the dataframe, which is unnecessary and could be expensive.