### PR TITLE
correcting feature labels in BandFeaturizer

### DIFF
--- a/matminer/featurizers/tests/test_bandstructure.py
+++ b/matminer/featurizers/tests/test_bandstructure.py
@@ -54,6 +54,7 @@ class BandstructureFeaturesTest(PymatgenTest):
     def test_BandFeaturizer(self):
         # silicon:
         bs_featurizer = BandFeaturizer(kpoints=self.si_kpts, nbands=5)
+        assert(len(bs_featurizer.feature_labels()) > 0)
         df_bf = bs_featurizer.featurize_dataframe(self.df, col_id='bs_line')
         self.assertAlmostEqual(df_bf['band_gap'][0], 0.612, 3)
         self.assertAlmostEqual(df_bf['direct_gap'][0], 2.557, 3)

--- a/matminer/featurizers/tests/test_bandstructure.py
+++ b/matminer/featurizers/tests/test_bandstructure.py
@@ -54,7 +54,7 @@ class BandstructureFeaturesTest(PymatgenTest):
     def test_BandFeaturizer(self):
         # silicon:
         bs_featurizer = BandFeaturizer(kpoints=self.si_kpts, nbands=5)
-        assert(len(bs_featurizer.feature_labels()) > 0)
+        self.assertTrue(len(bs_featurizer.feature_labels()) > 0)
         df_bf = bs_featurizer.featurize_dataframe(self.df, col_id='bs_line')
         self.assertAlmostEqual(df_bf['band_gap'][0], 0.612, 3)
         self.assertAlmostEqual(df_bf['direct_gap'][0], 2.557, 3)


### PR DESCRIPTION
This is to address the remaining issues in #84 but for BandFeaturizer:

- features stored in unordered, standard dictionary
- class attributes are initialized in the featurize() function
- feature_labels() can’t be called until after featurize() has been called

note that depending of whether or not self.kpoints is None, self.feature_labels() may be different.