### PR TITLE
Add VoronoiFingerprint and ChemicalSRO featurizers

### DIFF
--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -566,7 +566,6 @@ class CrystalSiteFingerprint(BaseFeaturizer):
                 r ** 2 * math.atan(x / math.sqrt(r ** 2 - x ** 2))))
 
 
-
 class VoronoiFingerprint(BaseFeaturizer):
     """
     Calculate the following sets of features based on Voronoi tessellation
@@ -578,8 +577,8 @@ class VoronoiFingerprint(BaseFeaturizer):
           for icosahedra, the Voronoi indices are [0,0,12,0,...];
 
     *i-fold symmetry indices
-     computed as n_i/sum(n_i), and i is in the range of 3-10, reflect the
-     strength of i-fold symmetry in local sites.
+     computed as n_i/sum(n_i), and i is in the range of 3-10.
+     reflect the strength of i-fold symmetry in local sites.
      e.g. for bcc lattice, the i-fold symmetry indices are [0,6/14,0,8/14,0,0...]
              indicating both 4-fold and a stronger 6-fold symmetries are present;
           for fcc/hcp lattice, the i-fold symmetry factors are [0,1,0,0,...],
@@ -588,7 +587,7 @@ class VoronoiFingerprint(BaseFeaturizer):
              indicating only 5-fold symmetry is present;
 
      *Weighted i-fold symmetry indices
-     if use_weights = True
+      if use_weights = True
 
      *Voronoi volume
       total volume of the Voronoi polyhedron around the target site
@@ -687,7 +686,7 @@ class VoronoiFingerprint(BaseFeaturizer):
                     voro_idx_list[len(vind) - 3] += 1
                     if self.use_weights:
                         for key, value in n_w.items():
-                            if (key.coords == vertices[sorted(nn)[1]]).all():
+                            if str(key.coords) == str(vertices[sorted(nn)[1]]):
                                 voro_idx_weights[len(vind) - 3] += value
 
                 except IndexError:

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -568,12 +568,22 @@ class CrystalSiteFingerprint(BaseFeaturizer):
 
 class VoronoiIndex(BaseFeaturizer):
     """
-    The Voronoi indices n_i and the fractional Voronoi indices n_i/sum(n_i) that
-    reflects the i-fold symmetry in the local sites.
-    n_i denotes the number of the i-edged faces, and i is in the range of 3-10 here.
+    Calculate two sets of features based on Voronoi index around each site:
+    Voronoi indices [n_i], where n_i denotes the number of i-edged faces,
+    and i is in the range of 3-10 here.
     e.g. for bcc lattice, the Voronoi indices are [0,6,0,8,0,0...]
          for fcc/hcp lattice, the Voronoi indices are [0,12,0,0,...]
          for icosahedra, the Voronoi indices are [0,0,12,0,...]
+
+    Fractional Voronoi indices, or say i-fold symmetry indices, computed as
+    n_i/sum(n_i), to reflects the strength of i-fold symmetry in local sites.
+    e.g. for bcc lattice, the i-fold symmetry factors are [0,6/14,0,8/14,0,0...]
+            indicating both 4-fold and a stronger 6-fold symmetry is present
+         for fcc/hcp lattice, the i-fold symmetry factors are [0,1,0,0,...],
+            indicating only 4-fold symmetry is present
+         for icosahedra, the Voronoi indices are [0,0,1,0,...],
+            indicating only 5-fold symmetry is present
+
     """
 
     def __init__(self, cutoff=6.0):
@@ -591,8 +601,8 @@ class VoronoiIndex(BaseFeaturizer):
             struct (Structure): Pymatgen Structure object.
             idx (int): index of target site in structure.
         Returns:
-            list including Voronoi indices, sum of Voronoi indices, and
-            fractional Voronoi indices
+            list of Voronoi indices and sum of Voronoi indices
+            list of fractional Voronoi indices
         """
 
         voro_index_result = []

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -572,14 +572,14 @@ class VoronoiFingerprint(BaseFeaturizer):
     analysis around the target site:
     -Voronoi indices {n_i}
      n_i denotes the number of i-edged facets, and i is in the range of 3-10.
-     e.g. for bcc lattice, the Voronoi indices are [0,6,0,8,0,0...];
+     e.g. for bcc lattice, the Voronoi indices are [0,6,0,8,...];
           for fcc/hcp lattice, the Voronoi indices are [0,12,0,0,...];
           for icosahedra, the Voronoi indices are [0,0,12,0,...];
 
     -i-fold symmetry indices
      computed as n_i/sum(n_i), and i is in the range of 3-10.
      reflect the strength of i-fold symmetry in local sites.
-     e.g. for bcc lattice, the i-fold symmetry indices are [0,6/14,0,8/14,0,0...]
+     e.g. for bcc lattice, the i-fold symmetry indices are [0,6/14,0,8/14,...]
              indicating both 4-fold and a stronger 6-fold symmetries are present;
           for fcc/hcp lattice, the i-fold symmetry factors are [0,1,0,0,...],
              indicating only 4-fold symmetry is present;
@@ -613,7 +613,6 @@ class VoronoiFingerprint(BaseFeaturizer):
         stats_vol (list of str): volume statistics types.
         stats_area (list of str): area statistics types.
         stats_dist (list of str): neighboring distance statistics types.
-
     """
 
     def __init__(self, cutoff=6.0, use_weights=False, stats_vol=None,
@@ -744,6 +743,32 @@ class VoronoiFingerprint(BaseFeaturizer):
 
     def implementors(self):
         return ['Qi Wang']
+
+
+class ChemicalSRO(BaseFeaturizer):
+    """
+     Chemical short-range ordering (SRO) features to evaluate the deviation
+     of local chemistry with the nominal composition of the structure.
+
+     f_el = N_el/(sum of N_el) - c_el,
+     where N_el is the number of each element type in the neighbors around
+     the target site, sum of N_el is the sum of all possible element types
+     (coordination number), and c_el is the composition of the specific
+     element in the entire structure.
+
+     Here the calculation is run for each element present in the structure.
+
+     A positive f_el indicating the "bonding" with the specific element
+     is favored around the target site;
+     A negative f_el means the "bonding" is not favored, at least around
+     the target site.
+
+     Args:
+         nn (NearNeighbor): instance of one of pymatgen's NearNeighbor
+                            classes.
+     Returns:
+
+     """
 
 
 class EwaldSiteEnergy:

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -760,7 +760,7 @@ class ChemicalSRO(BaseFeaturizer):
     Here the calculation is run for each element present in the structure.
 
     A positive f_el indicates the "bonding" with the specific element
-    is favored around the target site;
+    is favored, at least in the target site;
     A negative f_el indicates the "bonding" is not favored, at least
     in the target site.
 

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -614,12 +614,12 @@ class VoronoiFingerprint(BaseFeaturizer):
         """
         Args:
             cutoff (float): cutoff distance in determining the potential
-                  neighbors for Voronoi tessellation analysis
+                  neighbors for Voronoi tessellation analysis.
             use_weights(bool): whether to use weights to derive weighted
-                  i-fold symmetry indices
-            stats_vol (list of str): volume statistics types
-            stats_area (list of str): area statistics types
-            stats_dist (list of str): neighboring distance statistics types
+                  i-fold symmetry indices.
+            stats_vol (list of str): volume statistics types.
+            stats_area (list of str): area statistics types.
+            stats_dist (list of str): neighboring distance statistics types.
         """
 
         self.cutoff = cutoff
@@ -633,15 +633,16 @@ class VoronoiFingerprint(BaseFeaturizer):
 
     def vol_tetra(self, vt1, vt2, vt3, vt4):
         """
-        Calculate the volume of a tetrahedron, given vertices a,b,c and d
+        Calculate the volume of a tetrahedron, given the four vertices of vt1,
+        vt2, vt3 and vt4
         Args:
-            vt1: coordinates of vertex 1
-            vt2: coordinates of vertex 2
-            vt3: coordinates of vertex 3
-            vt4: coordinates of vertex 4
+            vt1: coordinates of vertex 1.
+            vt2: coordinates of vertex 2.
+            vt3: coordinates of vertex 3.
+            vt4: coordinates of vertex 4.
 
         Returns:
-            volume of the tetrahedron
+            volume of the tetrahedron.
         """
 
         vol_tetra = np.abs(np.dot((vt1 - vt4),
@@ -655,14 +656,14 @@ class VoronoiFingerprint(BaseFeaturizer):
             idx (int): index of target site in structure.
 
         Returns:
-            list of Voronoi indices
-            list of i-fold symmetry indices
-            list of weighted i-fold symmetry indices, if use_weights=True
-            Voronoi volume
-            list of Voronoi volume statistics
-            Voronoi area
-            list of Voronoi area statistics
-            list of neighboring distance statistics
+            list of Voronoi indices.
+            list of i-fold symmetry indices.
+            list of weighted i-fold symmetry indices, if use_weights=True.
+            Voronoi volume.
+            list of Voronoi volume statistics.
+            Voronoi area.
+            list of Voronoi area statistics.
+            list of neighboring distance statistics.
         """
 
         n_w = VoronoiNN(cutoff=self.cutoff).get_voronoi_polyhedra(struct, idx)

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -570,13 +570,13 @@ class VoronoiFingerprint(BaseFeaturizer):
     """
     Calculate the following sets of features based on Voronoi tessellation
     analysis around the target site:
-    *Voronoi indices {n_i}
+    -Voronoi indices {n_i}
      n_i denotes the number of i-edged facets, and i is in the range of 3-10.
      e.g. for bcc lattice, the Voronoi indices are [0,6,0,8,0,0...];
           for fcc/hcp lattice, the Voronoi indices are [0,12,0,0,...];
           for icosahedra, the Voronoi indices are [0,0,12,0,...];
 
-    *i-fold symmetry indices
+    -i-fold symmetry indices
      computed as n_i/sum(n_i), and i is in the range of 3-10.
      reflect the strength of i-fold symmetry in local sites.
      e.g. for bcc lattice, the i-fold symmetry indices are [0,6/14,0,8/14,0,0...]
@@ -586,41 +586,38 @@ class VoronoiFingerprint(BaseFeaturizer):
           for icosahedra, the Voronoi indices are [0,0,1,0,...],
              indicating only 5-fold symmetry is present;
 
-     *Weighted i-fold symmetry indices
-      if use_weights = True
+    -weighted i-fold symmetry indices
+     if use_weights = True
 
-     *Voronoi volume
-      total volume of the Voronoi polyhedron around the target site
+    -Voronoi volume
+     total volume of the Voronoi polyhedron around the target site
 
-     *Voronoi volume statistics of the sub_polyhedra formed by each facet
-      and the center site
-      e.g. stats_vol = ['mean', 'std_dev', 'minimum', 'maximum']
+    -Voronoi volume statistics of the sub_polyhedra formed by each facet
+     and the center site
+     e.g. stats_vol = ['mean', 'std_dev', 'minimum', 'maximum']
 
-     *Voronoi area
-      total area of the Voronoi polyhedron around the target site
+    -Voronoi area
+     total area of the Voronoi polyhedron around the target site
 
-     *Voronoi area statistics of the facets
-      e.g. stats_area = ['mean', 'std_dev', 'minimum', 'maximum']
+    -Voronoi area statistics of the facets
+     e.g. stats_area = ['mean', 'std_dev', 'minimum', 'maximum']
 
-     *Voronoi nearest-neighboring distance statistics
-      e.g. stats_dist = ['mean', 'std_dev', 'minimum', 'maximum']
+    -Voronoi nearest-neighboring distance statistics
+     e.g. stats_dist = ['mean', 'std_dev', 'minimum', 'maximum']
+
+    Args:
+        cutoff (float): cutoff distance in determining the potential
+            neighbors for Voronoi tessellation analysis.
+        use_weights(bool): whether to use weights to derive weighted
+            i-fold symmetry indices.
+        stats_vol (list of str): volume statistics types.
+        stats_area (list of str): area statistics types.
+        stats_dist (list of str): neighboring distance statistics types.
 
     """
 
     def __init__(self, cutoff=6.0, use_weights=False, stats_vol=None,
                  stats_area=None, stats_dist=None):
-
-        """
-        Args:
-            cutoff (float): cutoff distance in determining the potential
-                  neighbors for Voronoi tessellation analysis.
-            use_weights(bool): whether to use weights to derive weighted
-                  i-fold symmetry indices.
-            stats_vol (list of str): volume statistics types.
-            stats_area (list of str): area statistics types.
-            stats_dist (list of str): neighboring distance statistics types.
-        """
-
         self.cutoff = cutoff
         self.use_weights = use_weights
         self.stats_vol = ['mean', 'std_dev', 'minimum', 'maximum'] \
@@ -636,13 +633,12 @@ class VoronoiFingerprint(BaseFeaturizer):
         Calculate the volume of a tetrahedron, given the four vertices of vt1,
         vt2, vt3 and vt4
         Args:
-            vt1: coordinates of vertex 1.
-            vt2: coordinates of vertex 2.
-            vt3: coordinates of vertex 3.
-            vt4: coordinates of vertex 4.
-
+            vt1 (array-like): coordinates of vertex 1.
+            vt2 (array-like): coordinates of vertex 2.
+            vt3 (array-like): coordinates of vertex 3.
+            vt4 (array-like): coordinates of vertex 4.
         Returns:
-            volume of the tetrahedron.
+            vol_tetra (float): volume of the tetrahedron.
         """
 
         vol_tetra = np.abs(np.dot((vt1 - vt4),
@@ -654,16 +650,16 @@ class VoronoiFingerprint(BaseFeaturizer):
         Args:
             struct (Structure): Pymatgen Structure object.
             idx (int): index of target site in structure.
-
         Returns:
-            list of Voronoi indices.
-            list of i-fold symmetry indices.
-            list of weighted i-fold symmetry indices, if use_weights=True.
-            Voronoi volume.
-            list of Voronoi volume statistics.
-            Voronoi area.
-            list of Voronoi area statistics.
-            list of neighboring distance statistics.
+            voro_fingerprint (list of floats): Voronoi fingerprints
+                -Voronoi indices
+                -i-fold symmetry indices
+                -weighted i-fold symmetry indices (if use_weights = True)
+                -Voronoi volume
+                -Voronoi volume statistics
+                -Voronoi area
+                -Voronoi area statistics
+                -Voronoi area statistics
         """
 
         n_w = VoronoiNN(cutoff=self.cutoff).get_voronoi_polyhedra(struct, idx)

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -631,7 +631,8 @@ class VoronoiFingerprint(BaseFeaturizer):
         self.stats_dist = ['mean', 'std_dev', 'minimum', 'maximum'] \
             if stats_dist is None else stats_dist.copy()
 
-    def vol_tetra(self, vt1, vt2, vt3, vt4):
+    @staticmethod
+    def vol_tetra(vt1, vt2, vt3, vt4):
         """
         Calculate the volume of a tetrahedron, given the four vertices of vt1,
         vt2, vt3 and vt4
@@ -646,7 +647,7 @@ class VoronoiFingerprint(BaseFeaturizer):
         """
 
         vol_tetra = np.abs(np.dot((vt1 - vt4),
-                               np.cross((vt2 - vt4), (vt3 - vt4))))/6
+                                  np.cross((vt2 - vt4), (vt3 - vt4))))/6
         return vol_tetra
 
     def featurize(self, struct, idx):

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -602,7 +602,7 @@ class VoronoiIndex(BaseFeaturizer):
             idx (int): index of target site in structure.
         Returns:
             list of Voronoi indices and sum of Voronoi indices
-            list of fractional Voronoi indices
+            list of fractional Voronoi indices or say i-fold symmetry indices
         """
 
         voro_index_result = []

--- a/matminer/featurizers/tests/test_site.py
+++ b/matminer/featurizers/tests/test_site.py
@@ -7,7 +7,7 @@ from pymatgen.util.testing import PymatgenTest
 from pymatgen.analysis.local_env import VoronoiNN, JMolNN
 
 from matminer.featurizers.site import AGNIFingerprints, \
-    OPSiteFingerprint, EwaldSiteEnergy, VoronoiIndex, ChemEnvSiteFingerprint, \
+    OPSiteFingerprint, EwaldSiteEnergy, VoronoiFingerprint, ChemEnvSiteFingerprint, \
     CoordinationNumber
 
 class FingerprintTests(PymatgenTest):
@@ -128,20 +128,48 @@ class FingerprintTests(PymatgenTest):
         self.assertAlmostEqual(cevals[l.index('C:8')], 0.9953721, places=7)
         self.assertAlmostEqual(cevals[l.index('O:6')], 0, places=7)
 
-    # test Voronoi indices
-    def test_voronoi_site(self):
+    def test_voronoifingerprint(self):
         data = pd.DataFrame({'struct': [self.sc], 'site': [0]})
-        test_site_voronoi = VoronoiIndex()
+        test_site_voronoi = VoronoiFingerprint(use_weights=True)
         test_featurize = test_site_voronoi.featurize_dataframe(data, ['struct', 'site'])
-        self.assertAlmostEqual(test_featurize['voro_index_3'][0], 0.0)
-        self.assertAlmostEqual(test_featurize['voro_index_4'][0], 6.0)
-        self.assertAlmostEqual(test_featurize['voro_index_5'][0], 0.0)
-        self.assertAlmostEqual(test_featurize['voro_index_6'][0], 0.0)
-        self.assertAlmostEqual(test_featurize['voro_index_7'][0], 0.0)
-        self.assertAlmostEqual(test_featurize['voro_index_8'][0], 0.0)
-        self.assertAlmostEqual(test_featurize['voro_index_9'][0], 0.0)
-        self.assertAlmostEqual(test_featurize['voro_index_10'][0], 0.0)
-        self.assertAlmostEqual(test_featurize['voro_index_sum'][0], 6.0)
+        self.assertAlmostEqual(test_featurize['Voro_index_3'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Voro_index_4'][0], 6.0)
+        self.assertAlmostEqual(test_featurize['Voro_index_5'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Voro_index_6'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Voro_index_7'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Voro_index_8'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Voro_index_9'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Voro_index_10'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_index_3'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_index_4'][0], 1.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_index_5'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_index_6'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_index_7'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_index_8'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_index_9'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_index_10'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_weighted_index_3'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_weighted_index_4'][0], 1.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_weighted_index_5'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_weighted_index_6'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_weighted_index_7'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_weighted_index_8'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_weighted_index_9'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Symmetry_weighted_index_10'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Voro_vol_sum'][0], 43.614208)
+        self.assertAlmostEqual(test_featurize['Voro_area_sum'][0], 74.3424)
+        self.assertAlmostEqual(test_featurize['Voro_vol_mean'][0], 7.269034667)
+        self.assertAlmostEqual(test_featurize['Voro_vol_std_dev'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Voro_vol_minimum'][0], 7.269034667)
+        self.assertAlmostEqual(test_featurize['Voro_vol_maximum'][0], 7.269034667)
+        self.assertAlmostEqual(test_featurize['Voro_area_mean'][0], 12.3904)
+        self.assertAlmostEqual(test_featurize['Voro_area_std_dev'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Voro_area_minimum'][0], 12.3904)
+        self.assertAlmostEqual(test_featurize['Voro_area_maximum'][0], 12.3904)
+        self.assertAlmostEqual(test_featurize['Voro_dist_mean'][0], 3.52)
+        self.assertAlmostEqual(test_featurize['Voro_dist_std_dev'][0], 0.0)
+        self.assertAlmostEqual(test_featurize['Voro_dist_minimum'][0], 3.52)
+        self.assertAlmostEqual(test_featurize['Voro_dist_maximum'][0], 3.52)
 
     def test_ewald_site(self):
         ewald = EwaldSiteEnergy(accuracy=4)

--- a/matminer/featurizers/tests/test_site.py
+++ b/matminer/featurizers/tests/test_site.py
@@ -8,7 +8,7 @@ from pymatgen.analysis.local_env import VoronoiNN, JMolNN
 
 from matminer.featurizers.site import AGNIFingerprints, \
     OPSiteFingerprint, EwaldSiteEnergy, VoronoiFingerprint, ChemEnvSiteFingerprint, \
-    CoordinationNumber
+    CoordinationNumber, ChemicalSRO
 
 class FingerprintTests(PymatgenTest):
     def setUp(self):
@@ -46,7 +46,7 @@ class FingerprintTests(PymatgenTest):
         self.assertEqual(0.8, agni.etas[0])
         self.assertAlmostEqual(6 * np.exp(-(3.52 / 0.8) ** 2) * 0.5 * (np.cos(np.pi * 3.52 / 3.75) + 1), features[0])
         self.assertAlmostEqual(6 * np.exp(-(3.52 / 16) ** 2) * 0.5 * (np.cos(np.pi * 3.52 / 3.75) + 1), features[-1])
-        
+
         # Test that passing etas to constructor works
         new_etas = np.logspace(-4, 2, 6)
         agni = AGNIFingerprints(directions=['x', 'y', 'z'], etas=new_etas)
@@ -170,6 +170,24 @@ class FingerprintTests(PymatgenTest):
         self.assertAlmostEqual(test_featurize['Voro_dist_std_dev'][0], 0.0)
         self.assertAlmostEqual(test_featurize['Voro_dist_minimum'][0], 3.52)
         self.assertAlmostEqual(test_featurize['Voro_dist_maximum'][0], 3.52)
+
+    def test_chemicalSRO(self):
+        data = pd.DataFrame({'struct': [self.sc], 'site': [0]})
+        test_featurize = ChemicalSRO.from_preset("VoronoiNN").\
+            featurize_dataframe(data, ['struct', 'site'])
+        self.assertAlmostEqual(test_featurize['CSRO_Al_VoronoiNN'][0], 0.0)
+        test_featurize = ChemicalSRO(JMolNN(el_radius_updates = {"Al": 1.55})).\
+            featurize_dataframe(data, ['struct', 'site'])
+        self.assertAlmostEqual(test_featurize['CSRO_Al_JMolNN'][0], 0.0)
+        test_featurize = ChemicalSRO.from_preset("MinimumDistanceNN").\
+            featurize_dataframe(data, ['struct', 'site'])
+        self.assertAlmostEqual(test_featurize['CSRO_Al_MinimumDistanceNN'][0], 0.0)
+        test_featurize = ChemicalSRO.from_preset("MinimumOKeeffeNN").\
+            featurize_dataframe(data, ['struct', 'site'])
+        self.assertAlmostEqual(test_featurize['CSRO_Al_MinimumOKeeffeNN'][0], 0.0)
+        test_featurize = ChemicalSRO.from_preset("MinimumVIRENN").\
+            featurize_dataframe(data, ['struct', 'site'])
+        self.assertAlmostEqual(test_featurize['CSRO_Al_MinimumVIRENN'][0], 0.0)
 
     def test_ewald_site(self):
         ewald = EwaldSiteEnergy(accuracy=4)


### PR DESCRIPTION
Add VoronoiFingerprint site featurizer to calculate the following features related to Voronoi analysis:
- Voronoi indices
- i-fold symmetry indices
- Weighted i-fold symmetry indices
- Voronoi volume
- Voronoi volume statistics of the sub_polyhedra formed by each facet and the center site, including ['mean', 'std_dev', 'minimum', 'maximum']
- Voronoi area
- Voronoi area statistics of the facets, including ['mean', 'std_dev', 'minimum', 'maximum']
- Voronoi nearest-neighboring distance statistics, including ['mean', 'std_dev', 'minimum', 'maximum']

Later add ChemicalSRO site featurizer to evaluate the deviation of local chemistry from the nominal composition of the structure, indicating whether the "bonding" with each element type is "favored" or not in the target site.
