### PR TITLE
Avoid overwriting on input df columns + ignore_errors in BagofBonds

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -26,6 +26,13 @@ class BaseFeaturizer(object):
             updated Dataframe
         """
 
+        # Generate the feature labels
+        labels = self.feature_labels()
+
+        for col in df.columns.values:
+            if col in labels:
+                raise ValueError('"{}" exists in input dataframe'.format(col))
+
         # If only one column and user provided a string, put it inside a list
         if isinstance(col_id, string_types):
             col_id = [col_id]
@@ -38,16 +45,13 @@ class BaseFeaturizer(object):
                 features.append(self.featurize(*x))
             except:
                 if ignore_errors:
-                    features.append([float("nan")]
-                                    * len(self.feature_labels()))
+                    features.append([float("nan")] * len(labels))
                 else:
                     raise
 
-        # Generate the feature labels
-        labels = self.feature_labels()
-
         # Create dataframe with the new features
-        new_cols = dict(zip(labels, [pd.Series(x, index=df.index) for x in zip(*features)]))
+        new_cols = dict(zip(labels, [pd.Series(x, index=df.index) for x in
+                                     zip(*features)]))
 
         # Update the dataframe
         if inplace:

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -303,7 +303,7 @@ class AtomicOrbitals(BaseFeaturizer):
             LUMO_character: (str) orbital symbol ('s', 'p', 'd', or 'f')
             LUMO_element: (str) symbol of element for LUMO
             LUMO_energy: (float in eV) absolute energy of LUMO
-            bandgap: (float in eV)
+            gap_AO: (float in eV)
                 the estimated bandgap from HOMO and LUMO energeis
         '''
 
@@ -316,7 +316,7 @@ class AtomicOrbitals(BaseFeaturizer):
             feat['{}_character'.format(edge)] = homo_lumo[edge][1][-1]
             feat['{}_element'.format(edge)] = homo_lumo[edge][0]
             feat['{}_energy'.format(edge)] = homo_lumo[edge][2]
-        feat['gap'] = feat['LUMO_energy'] - feat['HOMO_energy']
+        feat['gap_AO'] = feat['LUMO_energy'] - feat['HOMO_energy']
 
         return list(feat.values())
 

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -326,7 +326,7 @@ class AtomicOrbitals(BaseFeaturizer):
             feat.extend(['{}_character'.format(edge),
                          '{}_element'.format(edge),
                          '{}_energy'.format(edge)])
-        feat.append("gap")
+        feat.append("gap_AO")
         return feat
 
     def citations(self):

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -1079,7 +1079,8 @@ class BagofBonds(BaseFeaturizer):
         """
 
         # unified_bonds attribute only lives if dataframe is being featurized.
-        self.unified_bonds = self.enumerate_all_bonds(df[col_id])
+        self.unified_bonds = self.enumerate_all_bonds(df[col_id],
+                                                      ignore_errors=ignore_errors)
         df = super(BagofBonds, self).featurize_dataframe(df, col_id,
                                                          ignore_errors=ignore_errors,
                                                          inplace=inplace)
@@ -1107,7 +1108,7 @@ class BagofBonds(BaseFeaturizer):
         bond_types = [k[0] + '-' + k[1] for k in het_bonds + hom_bonds]
         return sorted(bond_types)
 
-    def enumerate_all_bonds(self, structures):
+    def enumerate_all_bonds(self, structures, ignore_errors=False):
         """
         Identify all the unique, possible bonds types of all structures present,
         and create the 'unified' bonds list.
@@ -1121,10 +1122,16 @@ class BagofBonds(BaseFeaturizer):
         """
         bond_types = []
         for s in structures:
-            bts = self.enumerate_bonds(s)
-            for bt in bts:
-                if bt not in bond_types:
-                    bond_types.append(bt)
+            try:
+                bts = self.enumerate_bonds(s)
+                for bt in bts:
+                    if bt not in bond_types:
+                        bond_types.append(bt)
+            except:
+                if ignore_errors:
+                    continue
+                else:
+                    raise
         return tuple(sorted(bond_types))
 
     def featurize(self, s):

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -1122,16 +1122,12 @@ class BagofBonds(BaseFeaturizer):
         """
         bond_types = []
         for s in structures:
-            try:
-                bts = self.enumerate_bonds(s)
-                for bt in bts:
-                    if bt not in bond_types:
-                        bond_types.append(bt)
-            except:
-                if ignore_errors:
-                    continue
-                else:
-                    raise
+            if s is None and ignore_errors:
+                continue
+            bts = self.enumerate_bonds(s)
+            for bt in bts:
+                if bt not in bond_types:
+                    bond_types.append(bt)
         return tuple(sorted(bond_types))
 
     def featurize(self, s):

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -139,7 +139,7 @@ class CompositionFeaturesTest(PymatgenTest):
         self.assertEqual(df_atomic_orbitals['LUMO_character'][0], 'd')
         self.assertEqual(df_atomic_orbitals['LUMO_element'][0], 'Fe')
         self.assertEqual(df_atomic_orbitals['LUMO_energy'][0], -0.295049)
-        self.assertEqual(df_atomic_orbitals['gap'][0], 0.0)
+        self.assertEqual(df_atomic_orbitals['gap_AO'][0], 0.0)
 
     def test_band_center(self):
         df_band_center = BandCenter().featurize_dataframe(self.df, col_id="composition")

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -355,6 +355,7 @@ class StructureFeaturesTest(PymatgenTest):
         # Test to make sure bad_bond_values (bbv) are still changed correctly
         # and check inplace behavior of featurize dataframe.
         bob_voronoi.bbv = 0.0
+        df = pd.DataFrame.from_dict({'s': s_list})
         df = bob_voronoi.featurize_dataframe(df, 's')
         self.assertArrayEqual(df['C-C bond frac.'].as_matrix(), [1.0, 0.0])
         self.assertArrayEqual(df['Al-Ni bond frac.'].as_matrix(), [0.0, 0.5])


### PR DESCRIPTION
3 small changes:

1) extended the implementation of ignore_errors inside BagofBonds so it will skip entries with bad structures.
2) rename gap to gap_AO in AtomicOrbitals as "gap" has a higher chance of already being used in input df. 
3) extended the logic in previous point and raise if input df column names and feature_labels overlap.