### PR TITLE
strictly checking feature_labels vs. current labels to avoid overwritting

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -40,6 +40,11 @@ class BaseFeaturizer(object):
         # Generate the feature labels
         labels = self.feature_labels()
 
+        # Check names to avoid overwriting the current columns
+        for col in df.columns.values:
+            if col in labels:
+                raise ValueError('"{}" exists in input dataframe'.format(col))
+            
         # Compute the features
         features = self.featurize_many(df[col_id].values, n_jobs, ignore_errors)
 

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -44,7 +44,7 @@ class BaseFeaturizer(object):
         for col in df.columns.values:
             if col in labels:
                 raise ValueError('"{}" exists in input dataframe'.format(col))
-            
+
         # Compute the features
         features = self.featurize_many(df[col_id].values, n_jobs, ignore_errors)
 

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -303,7 +303,7 @@ class AtomicOrbitals(BaseFeaturizer):
             LUMO_character: (str) orbital symbol ('s', 'p', 'd', or 'f')
             LUMO_element: (str) symbol of element for LUMO
             LUMO_energy: (float in eV) absolute energy of LUMO
-            bandgap: (float in eV)
+            gap_AO: (float in eV)
                 the estimated bandgap from HOMO and LUMO energeis
         '''
 

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -316,7 +316,7 @@ class AtomicOrbitals(BaseFeaturizer):
             feat['{}_character'.format(edge)] = homo_lumo[edge][1][-1]
             feat['{}_element'.format(edge)] = homo_lumo[edge][0]
             feat['{}_energy'.format(edge)] = homo_lumo[edge][2]
-        feat['gap'] = feat['LUMO_energy'] - feat['HOMO_energy']
+        feat['gap_AO'] = feat['LUMO_energy'] - feat['HOMO_energy']
 
         return list(feat.values())
 
@@ -326,7 +326,7 @@ class AtomicOrbitals(BaseFeaturizer):
             feat.extend(['{}_character'.format(edge),
                          '{}_element'.format(edge),
                          '{}_energy'.format(edge)])
-        feat.append("gap")
+        feat.append("gap_AO")
         return feat
 
     def citations(self):

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -138,6 +138,7 @@ class TestBaseClass(PymatgenTest):
 
         # Multi-argument
         s = self.multiargs
+        data = self.make_test_data()
         data['x2'] = [4, 5, 6]
         data = s.featurize_dataframe(data, ['x', 'x2'], n_jobs=self.n_jobs)
         self.assertArrayAlmostEqual(data['y'], [5, 7, 9])

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -139,7 +139,7 @@ class CompositionFeaturesTest(PymatgenTest):
         self.assertEqual(df_atomic_orbitals['LUMO_character'][0], 'd')
         self.assertEqual(df_atomic_orbitals['LUMO_element'][0], 'Fe')
         self.assertEqual(df_atomic_orbitals['LUMO_energy'][0], -0.295049)
-        self.assertEqual(df_atomic_orbitals['gap'][0], 0.0)
+        self.assertEqual(df_atomic_orbitals['gap_AO'][0], 0.0)
 
     def test_band_center(self):
         df_band_center = BandCenter().featurize_dataframe(self.df, col_id="composition")

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -355,6 +355,7 @@ class StructureFeaturesTest(PymatgenTest):
         # Test to make sure bad_bond_values (bbv) are still changed correctly
         # and check inplace behavior of featurize dataframe.
         bob_voronoi.bbv = 0.0
+        df = pd.DataFrame.from_dict({'s': s_list})
         df = bob_voronoi.featurize_dataframe(df, 's')
         self.assertArrayEqual(df['C-C bond frac.'].as_matrix(), [1.0, 0.0])
         self.assertArrayEqual(df['Al-Ni bond frac.'].as_matrix(), [0.0, 0.5])


### PR DESCRIPTION
This is to address the first 2 parts of #127 . Some new tests had to be updated.