### PR TITLE
BagofBonds update

### DIFF
--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -1034,8 +1034,7 @@ class BagofBonds(BaseFeaturizer):
             structure-bond combinations which can not physically exist, but
             exist in the unified dataframe. For example, if a dataframe contains
             structures of BaLiP and BaTiO3, determines the value to place in
-            the Li-P column for the BaTiO3 row; by default, is None, resulting
-            in NaN.
+            the Li-P column for the BaTiO3 row; by default, is 0.
         allowed_bonds ([str]): A list of allowed bond types; limits the possible
             columns in the output dataframe. If a structure has a bond type not
             in allowed_bonds, the bond is skipped and all allowed bonds are
@@ -1050,7 +1049,7 @@ class BagofBonds(BaseFeaturizer):
             bond chosen.
     """
 
-    def __init__(self, nn, bbv=None, allowed_bonds=None, approx_bonds=False):
+    def __init__(self, nn, bbv=0.0, allowed_bonds=None, approx_bonds=False):
         self.nn = nn
         self.bbv = bbv
         self.allowed_bonds = allowed_bonds
@@ -1236,22 +1235,20 @@ class BagofBonds(BaseFeaturizer):
                 d_min = None
                 for ubs in ubonds_species.keys():
 
-                    u_mends = [j.element.mendeleev_no for j in ubs]
-                    l_mends = [j.element.mendeleev_no for j in lbs]
-
                     # The distance between bonds is euclidean. To get a good
                     # measure of the coordinate between mendeleev numbers for
                     # each specie, we use the minumum difference. ie, for
                     # finding the distance between Na-O and O-Li, we would
                     # not want the distance between (Na and O) and (O and Li),
                     # we want the distance between (Na and Li) and (O and O).
-                    d1 = min([abs(u_mends[0] - l_mends[0]),
-                              abs(u_mends[1] - l_mends[0])])
 
-                    d2 = min([abs(u_mends[0] - l_mends[1]),
-                              abs(u_mends[1] - l_mends[1])])
+                    u_mends = sorted([j.element.mendeleev_no for j in ubs])
+                    l_mends = sorted([j.element.mendeleev_no for j in lbs])
 
-                    d = (d1**2.0 + d2**2.0)**0.5
+                    d0 = u_mends[0] - l_mends[0]
+                    d1 = u_mends[1] - l_mends[1]
+
+                    d = (d0**2.0 + d1**2.0)**0.5
                     if not d_min:
                         d_min = d
                         nearest = [ubs]

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -15,8 +15,7 @@ from pymatgen.analysis.defects.point_defects import \
 from pymatgen.analysis.ewald import EwaldSummation
 from pymatgen.core.periodic_table import Specie, Element
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-import pymatgen.analysis.local_env
-
+import pymatgen.analysis.local_env as pmg_le
 from matminer.featurizers.base import BaseFeaturizer
 from matminer.featurizers.site import OPSiteFingerprint, CrystalSiteFingerprint, \
     CoordinationNumber
@@ -646,7 +645,7 @@ class OrbitalFieldMatrix(BaseFeaturizer):
                 counts: number of identical sites for each ofm
         """
         ofms = []
-        vnn = VoronoiNN(allow_pathological=True)
+        vnn = pmg_le.VoronoiNN(allow_pathological=True)
         if symm:
             symm_struct = SpacegroupAnalyzer(struct).get_symmetrized_structure()
             indices = [lst[0] for lst in symm_struct.equivalent_indices]
@@ -1074,7 +1073,7 @@ class BagofBonds(BaseFeaturizer):
         Returns:
             CoordinationNumber from a preset.
         """
-        nn = getattr(pymatgen.analysis.local_env, preset)
+        nn = getattr(pmg_le, preset)
         return BagofBonds(nn())
 
     def featurize_dataframe(self, df, col_id, *args, **kwargs):

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -1016,6 +1016,7 @@ class BagofBonds(BaseFeaturizer):
     """
     Compute the number of each kind of bond in a structure, as a fraction of
     the total number of bonds, based on NearestNeighbors.
+
     For example, in a structure with 2 Li-O bonds and 3 Li-P bonds:
 
     Li-0: 0.4
@@ -1059,6 +1060,7 @@ class BagofBonds(BaseFeaturizer):
                              "are enabled. Define a list of allowed bonds or "
                              "set approx_bonds=False.")
 
+        self._token = ' - '
         self._dataframe_featurizing = False
 
     @staticmethod
@@ -1103,8 +1105,7 @@ class BagofBonds(BaseFeaturizer):
         self._dataframe_featurizing = False
         return df
 
-    @staticmethod
-    def enumerate_bonds(s):
+    def enumerate_bonds(self, s):
         """
         Lists out all the bond possibilities in a single structure.
 
@@ -1121,7 +1122,7 @@ class BagofBonds(BaseFeaturizer):
         het_bonds = list(itertools.combinations(els, 2))
         het_bonds = [tuple(sorted([str(i) for i in j])) for j in het_bonds]
         hom_bonds = [(str(el), str(el)) for el in els]
-        bond_types = [k[0] + ' - ' + k[1] for k in het_bonds + hom_bonds]
+        bond_types = [k[0] + self._token + k[1] for k in het_bonds + hom_bonds]
         return sorted(bond_types)
 
     def enumerate_all_bonds(self, structures):
@@ -1165,13 +1166,13 @@ class BagofBonds(BaseFeaturizer):
                 raise TypeError("Bonds must be specified as strings between"
                                 "elements or species, for example Cl-Cs")
             bond = bond.replace(" bond frac.", "")
-            species = sorted(bond.split(" - "))
-            bonds[i] = " - ".join(species)
+            species = sorted(bond.split(self._token))
+            bonds[i] = self._token.join(species)
         return tuple(sorted(bonds))
 
     def _species_from_bondstr(self, bondstr):
         """
-        Create a tuple of species objects from a bond string.
+        Create a 2-tuple of species objects from a bond string.
 
         Args:
             bondstr (str): A string representing a bond between elements or
@@ -1182,7 +1183,7 @@ class BagofBonds(BaseFeaturizer):
                 order.
         """
         species = []
-        for ss in bondstr.split(" - "):
+        for ss in bondstr.split(self._token):
             try:
                 species.append(Specie.from_string(ss))
             except ValueError:
@@ -1326,7 +1327,7 @@ class BagofBonds(BaseFeaturizer):
 
             for neigh in nearest:
                 btup = tuple(sorted([str(origin), str(neigh.specie)]))
-                b = btup[0] + ' - ' + btup[1]
+                b = btup[0] + self._token + btup[1]
                 # The bond will not be in bonds if it is a forbidden bond
                 # (when a local bond is not in allowed_bonds)
                 tot_bonds += 1.0

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -14,8 +14,7 @@ from pymatgen.analysis.defects.point_defects import \
 from pymatgen.analysis.ewald import EwaldSummation
 from pymatgen.core.periodic_table import Specie, Element
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen.analysis.local_env import VoronoiNN, JMolNN, \
-    MinimumDistanceNN, MinimumOKeeffeNN, MinimumVIRENN
+import pymatgen.analysis.local_env
 
 from matminer.featurizers.base import BaseFeaturizer
 from matminer.featurizers.site import OPSiteFingerprint, CrystalSiteFingerprint, \
@@ -1052,20 +1051,10 @@ class BagofBonds(BaseFeaturizer):
         Returns:
             CoordinationNumber from a preset.
         """
-        if preset == "VoronoiNN":
-            return BagofBonds(VoronoiNN())
-        elif preset == "JMolNN":
-            return BagofBonds(JMolNN())
-        elif preset == "MinimumDistanceNN":
-            return BagofBonds(MinimumDistanceNN())
-        elif preset == "MinimumOKeeffeNN":
-            return BagofBonds(MinimumOKeeffeNN())
-        elif preset == "MinimumVIRENN":
-            return BagofBonds(MinimumVIRENN())
-        else:
-            raise RuntimeError('Unknown preset.')
+        nn = getattr(pymatgen.analysis.local_env, preset)
+        return BagofBonds(nn())
 
-    def featurize_dataframe(self, df, col_id, ignore_errors=False, inplace=True):
+    def featurize_dataframe(self, df, col_id, *args, **kwargs):
         """
         Compute features for all entries contained in input dataframe.
         Necessary for returning the correct unified dataframe.
@@ -1080,9 +1069,8 @@ class BagofBonds(BaseFeaturizer):
 
         # unified_bonds attribute only lives if dataframe is being featurized.
         self.unified_bonds = self.enumerate_all_bonds(df[col_id])
-        df = super(BagofBonds, self).featurize_dataframe(df, col_id,
-                                                         ignore_errors=ignore_errors,
-                                                         inplace=inplace)
+        df = super(BagofBonds, self).featurize_dataframe(df, col_id, *args,
+                                                         **kwargs)
         delattr(self, 'unified_bonds')
         return df
 

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -337,8 +337,8 @@ class StructureFeaturesTest(PymatgenTest):
         bob_voronoi = BagofBonds.from_preset("VoronoiNN")
         bond_fracs = bob_voronoi.featurize(self.nacl)
         bond_names = bob_voronoi.feature_labels()
-        ref = {'Na+-Na+ bond frac.': 0.25, 'Cl--Na+ bond frac.': 0.5,
-               'Cl--Cl- bond frac.': 0.25}
+        ref = {'Na+ - Na+ bond frac.': 0.25, 'Cl- - Na+ bond frac.': 0.5,
+               'Cl- - Cl- bond frac.': 0.25}
         self.assertDictEqual(dict(zip(bond_names, bond_fracs)), ref)
 
         # Test to make sure dataframe behavior is as intended
@@ -347,19 +347,19 @@ class StructureFeaturesTest(PymatgenTest):
         df = bob_voronoi.featurize_dataframe(df, 's')
 
         # Ensure all data is properly labelled and organized
-        self.assertArrayEqual(df['C-C bond frac.'].as_matrix(), [1.0, np.nan])
-        self.assertArrayEqual(df['Al-Ni bond frac.'].as_matrix(), [np.nan, 0.5])
-        self.assertArrayEqual(df['Al-Al bond frac.'].as_matrix(), [np.nan, 0.0])
-        self.assertArrayEqual(df['Ni-Ni bond frac.'].as_matrix(), [np.nan, 0.5])
+        self.assertArrayEqual(df['C - C bond frac.'].as_matrix(), [1.0, np.nan])
+        self.assertArrayEqual(df['Al - Ni bond frac.'].as_matrix(), [np.nan, 0.5])
+        self.assertArrayEqual(df['Al - Al bond frac.'].as_matrix(), [np.nan, 0.0])
+        self.assertArrayEqual(df['Ni - Ni bond frac.'].as_matrix(), [np.nan, 0.5])
 
         # Test to make sure bad_bond_values (bbv) are still changed correctly
         # and check inplace behavior of featurize dataframe.
         bob_voronoi.bbv = 0.0
         df = bob_voronoi.featurize_dataframe(df, 's')
-        self.assertArrayEqual(df['C-C bond frac.'].as_matrix(), [1.0, 0.0])
-        self.assertArrayEqual(df['Al-Ni bond frac.'].as_matrix(), [0.0, 0.5])
-        self.assertArrayEqual(df['Al-Al bond frac.'].as_matrix(), [0.0, 0.0])
-        self.assertArrayEqual(df['Ni-Ni bond frac.'].as_matrix(), [0.0, 0.5])
+        self.assertArrayEqual(df['C - C bond frac.'].as_matrix(), [1.0, 0.0])
+        self.assertArrayEqual(df['Al - Ni bond frac.'].as_matrix(), [0.0, 0.5])
+        self.assertArrayEqual(df['Al - Al bond frac.'].as_matrix(), [0.0, 0.0])
+        self.assertArrayEqual(df['Ni - Ni bond frac.'].as_matrix(), [0.0, 0.5])
 
 
 if __name__ == '__main__':

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -335,6 +335,7 @@ class StructureFeaturesTest(PymatgenTest):
         self.assertArrayEqual(bob_md.featurize(self.diamond_no_oxi), [1.0])
 
         bob_voronoi = BagofBonds.from_preset("VoronoiNN")
+        bob_voronoi.bbv = float("nan")
         bond_fracs = bob_voronoi.featurize(self.nacl)
         bond_names = bob_voronoi.feature_labels()
         ref = {'Na+ - Na+ bond frac.': 0.25, 'Cl- - Na+ bond frac.': 0.5,


### PR DESCRIPTION
## Summary
- Performance improvements
- Made BoB presets better as mentioned in #128 
- Added `allowed_bonds` in BoB
- Added `approx_bonds` in BoB
- originally brought up in #127 

## Details
- Define `allowed_bonds` to limit the kinds of bonds which can be returned. If a structure has a forbidden bond, skips it and returns all other bonds normally (including bad bond values, where the forbidden list has bonds the structure being featurized does not). This can result in some rows having bond fractions summing to less than 1. 

- Allowed bonds can be defined by the list of feature labels a BoB object returns after featurization (`bob.feature_labels()`)

- If you do not want `allowed_bonds` to skip forbidden bonds, set `approx_bonds` to true to approximate forbidden bonds with chemically similar bonds found in `allowed_bonds`. Chemically similar bonds are determined by finding the bond in `allowed_bonds` with the smallest "distance" to the forbidden bond. Approximate bonds with equal distances to the forbidden bond divide the bond fraction equally among them. 

- The "distance" between bonds is determined by converting each bond into a 2-tuple of mendeleev numbers (MN) from their species, so each bond gets an (x,y) coordinate in MN space. A bond's x and y are swapped automatically if necessary (ie if we are comparing (O-Li bond) and (Na-O bond), making sure we calculate the MN distance between (Li and Na) and (O and O), _not_ (Li and O) and (O and Na)). Then the distance between (x1, y1) and (x2, y2) is Euclidean. 

## Examples
Get dataframe of some Na-O and Li-O compounds
```python
df = mpr.get_dataframe(criteria={"material_id": {"$in": ['mp-1960', 'mp-841', 'mp-1018789', 'mp-2352', 'mp-1901']}}, properties=['structure', 'spacegroup.number', 'pretty_formula'])
```
Featurize only the LiO compounds, for training:
```python
bob = BagofBonds.from_preset("MinimumDistanceNN")
print(bob.featurize_dataframe(df.iloc[[0, 2, 4]], 'structure'))
```
```
                                                     structure  spacegroup.number pretty_formula  Li - Li bond frac.  Li - O bond frac.  O - O bond frac.
material_id                                                                                                                                              
mp-1018789   {'lattice': {'a': 3.98566942, 'c': 2.96110099,...                 58           LiO2                 0.0           0.750000          0.250000
mp-1960      {'lattice': {'a': 3.291071792359756, 'c': 3.29...                225           Li2O                 0.0           1.000000          0.000000
mp-841       {'lattice': {'a': 3.18036198, 'c': 7.70352187,...                194          Li2O2                 0.0           0.857143          0.142857
```
Set the allowed bonds to the feature_labels of the previous featurization. Featurize the dataframe allowing only bonds containing Li and O, say, for testing:
```python
allowed = bob.feature_labels()
bob.allowed_bonds = allowed
print(bob.featurize_dataframe(df.iloc[[1, 3]], 'structure'))
```
```
                                                     structure  spacegroup.number pretty_formula  Li - Li bond frac.  Li - O bond frac.  O - O bond frac.
material_id                                                                                                                                              
mp-1901      {'lattice': {'a': 3.47402655, 'c': 5.67466155,...                 58           NaO2                 NaN                NaN              0.25
mp-2352      {'lattice': {'a': 3.9563243674727504, 'c': 3.9...                225           Na2O                 NaN                NaN              0.00
```
The Na-O and Na-Na bonds were skipped, because they was not in allowed_bonds. The `NaN` values are the bad_bond_values, which can be set with `bob.bbv`. 
If we do not want the Na-O and Na-Na bonds skipped, use `approx_bonds` to approximate these bonds with their most chemically similar, Li-O and Li-Li. 
```python
bob.approx_bonds = True
print(bob.featurize_dataframe(df.iloc[[1, 3]], 'structure'))
```
```
                                                     structure  spacegroup.number pretty_formula  Li - Li bond frac.  Li - O bond frac.  O - O bond frac.
material_id                                                                                                                                              
mp-1901      {'lattice': {'a': 3.47402655, 'c': 5.67466155,...                 58           NaO2                 0.0               0.75              0.25
mp-2352      {'lattice': {'a': 3.9563243674727504, 'c': 3.9...                225           Na2O                 0.0               1.00              0.00
```




