### PR TITLE
Adjust ChemicalSRO with new featurize_df+minor comments modification

### DIFF
--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -923,8 +923,6 @@ class CohesiveEnergy(BaseFeaturizer):
             "Physics, 8th Edition}}, year = {2005}}"]
 
 
-# TODO: read data file only once!! (on init, then store)
-# TODO: general code review, typo fixes, etc
 class Miedema(BaseFeaturizer):
     """
     Class to calculate the formation enthalpies of the intermetallic compound,
@@ -979,14 +977,12 @@ class Miedema(BaseFeaturizer):
                          'structural_stability'
 
     Returns:
-        a list of Miedema formation enthalpies (per atom) of target structures
-        for a given composition:
-            formation_enthalpy_inter: for interatomic compound
-            formation_enthalpy_ss: for solid solution, can be divided into
+        (list of floats) Miedema formation enthalpies (per atom)
+            -formation_enthalpy_inter: for interatomic compound
+            -formation_enthalpy_ss: for solid solution, can be divided into
                                    'min', 'fcc', 'bcc', 'hcp', 'no_latt'
                                     for different lattice_types
-            formation_enthalpy_amor: for amorphous phase
-
+            -formation_enthalpy_amor: for amorphous phase
     """
 
     data_dir = os.path.join(module_dir, "..", "utils", "data_files")
@@ -1017,16 +1013,14 @@ class Miedema(BaseFeaturizer):
                                       format(self, data_source))
 
     def deltaH_chem(self, elements, fracs, struct):
-        """chemical term of formation enthalpy
-
+        """
+        Chemical term of formation enthalpy
         Args:
             elements (list of str): list of elements
             fracs (list of floats): list of atomic fractions
             struct (str): 'inter', 'ss' or 'amor'
-
         Returns:
             deltaH_chem (float): chemical term of formation enthalpy
-
         """
         for el in elements:
             if el not in self.df_dataset.index:
@@ -1085,19 +1079,16 @@ class Miedema(BaseFeaturizer):
 
         deltaH_chem = (f_alloy[0] * fracs[0] * v_alloy[0] * eta_ab +
                        np.dot(fracs, H_trans))
-
         return deltaH_chem
 
     def deltaH_elast(self, elements, fracs):
-        """elastic term of formation enthalpy
-
+        """
+        Elastic term of formation enthalpy
         Args:
             elements (list of str): list of elements
             fracs (list of floats): list of atomic fractions
-
         Returns:
             deltaH_elastic (float): elastic term of formation enthalpy
-
         """
         for el in elements:
             if el not in self.df_dataset.index:
@@ -1142,20 +1133,17 @@ class Miedema(BaseFeaturizer):
 
         deltaH_elast = (np.multiply.reduce(fracs) *
                         (fracs[1] * Hab_elast + fracs[0] * Hba_elast))
-
         return deltaH_elast
 
     def deltaH_struct(self, elements, fracs, latt):
-        """structural term of formation enthalpy, only for solid solution
-
+        """
+        Structural term of formation enthalpy, only for solid solution
         Args:
             elements (list of str): list of elements
             fracs (list of floats): list of atomic fractions
             latt (str): 'fcc', 'bcc', 'hcp' or 'no_latt'
-
         Returns:
             deltaH_struct (float): structural term of formation enthalpy
-
         """
         for el in elements:
             if el not in self.df_dataset.index:
@@ -1202,15 +1190,13 @@ class Miedema(BaseFeaturizer):
         return deltaH_struct
 
     def deltaH_topo(self, elements, fracs):
-        """topological term of formation enthalpy, only for amorphous phase
-
+        """
+        Topological term of formation enthalpy, only for amorphous phase
         Args:
             elements (list of str): list of elements
             fracs (list of floats): list of atomic fractions
-
         Returns:
             deltaH_topo (float): topological term of formation enthalpy
-
         """
         for el in elements:
             if el not in self.df_dataset.index:
@@ -1223,16 +1209,14 @@ class Miedema(BaseFeaturizer):
         return deltaH_topo
 
     def featurize(self, comp):
-        """Get Miedema formation enthalpies of target structures: inter, amor,
-           ss (can be further divided into 'min', 'fcc', 'bcc', 'hcp', 'no_latt'
-               for different lattice_types)
-
+        """
+        Get Miedema formation enthalpies of target structures: inter, amor,
+        ss (can be further divided into 'min', 'fcc', 'bcc', 'hcp', 'no_latt'
+            for different lattice_types)
         Args:
             comp: Pymatgen composition object
-
         Returns:
             miedema (list of floats): formation enthalpies of target structures
-
         """
         el_amt = comp.fractional_composition.get_el_amt_dict()
         elements = sorted(el_amt.keys(), key=lambda sym: get_el_sp(sym).X)

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -639,7 +639,6 @@ class VoronoiFingerprint(BaseFeaturizer):
         Returns:
             (float): volume of the tetrahedron.
         """
-
         vol_tetra = np.abs(np.dot((vt1 - vt4),
                                   np.cross((vt2 - vt4), (vt3 - vt4))))/6
         return vol_tetra
@@ -661,7 +660,6 @@ class VoronoiFingerprint(BaseFeaturizer):
                 -Voronoi area statistics
                 -Voronoi area statistics
         """
-
         n_w = VoronoiNN(cutoff=self.cutoff).get_voronoi_polyhedra(struct, idx)
         voro_idx_list = np.array([0, 0, 0, 0, 0, 0, 0, 0])
         voro_idx_weights = np.array([0., 0., 0., 0., 0., 0., 0., 0.])
@@ -760,7 +758,7 @@ class ChemicalSRO(BaseFeaturizer):
     Here the calculation is run for each element present in the structure.
 
     A positive f_el indicates the "bonding" with the specific element
-    is favored, at least in the target site;
+    is favored, at lea the target site;
     A negative f_el indicates the "bonding" is not favored, at least
     in the target site.
 
@@ -795,7 +793,50 @@ class ChemicalSRO(BaseFeaturizer):
 
     def __init__(self, nn):
         self.nn = nn
-        self.elements = None
+        self.el_amt_dict = None
+        self.el_list = None
+
+    @staticmethod
+    def cal_el_amt(structs):
+        """
+        Identify and "store" the element types and composition of structures,
+        avoiding repeated calculation of composition while featurizing many
+        sites in one structure.
+        Args:
+             structs (pandas series): series of pymatgen Structures
+        Returns:
+
+        """
+        el_amt_dict = {}
+        el_list = set()
+        for s in structs.values:
+            if str(s) not in el_amt_dict.keys():
+                el_amt = s.composition.fractional_composition.\
+                         get_el_amt_dict()
+                el_amt_dict[str(s)] = el_amt
+                elements = set(el_amt.keys())
+                el_list = el_list | elements
+        return list(el_list), el_amt_dict
+
+    def featurize_dataframe(self, df, col_id, ignore_errors=True,
+                            inplace=True, n_jobs=1):
+        """
+        Featurize the dataframe with ChemicalSRO features.
+        Args:
+            df (Pandas dataframe): Dataframe containing input data
+            col_id (str or [str]): The dataframe key corresponding to structures
+        Returns:
+            (Pandas dataframe) ChemicalSRO-featurized dataframe
+        """
+        self.el_list, self.el_amt_dict = self.cal_el_amt(df[col_id[0]])
+        df = super(ChemicalSRO, self).\
+             featurize_dataframe(df, col_id,
+                                 ignore_errors=ignore_errors,
+                                 inplace=inplace,
+                                 n_jobs=n_jobs)
+        delattr(self, 'el_list')
+        delattr(self, 'el_amt_dict')
+        return df
 
     def featurize(self, struct, idx):
         """
@@ -806,18 +847,19 @@ class ChemicalSRO(BaseFeaturizer):
         Returns:
             (list of floats): Chemical SRO features for each element.
         """
-        el_amt = struct.composition.fractional_composition.get_el_amt_dict()
-        self.elements = el_amt.keys()
+        csro_el = [np.nan]*len(self.el_list)
+        el_amt = self.el_amt_dict[str(struct)]
         nn_list = self.nn.get_nn(struct, idx)
         nn_el_amt = dict.fromkeys(el_amt, 0)
         for nn in nn_list:
             nn_el_amt[str(nn.specie)] += 1/len(nn_list)
-        csro_el = [el_amt[el] - nn_el_amt[el] for el in self.elements]
+        for el in el_amt.keys():
+            csro_el[self.el_list.index(el)] = nn_el_amt[el] - el_amt[el]
         return csro_el
 
     def feature_labels(self):
         return ['CSRO_{}_{}'.format(el, self.nn.__class__.__name__)
-                for el in self.elements]
+                for el in self.el_list]
 
     def citations(self):
         citations = []

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -758,7 +758,7 @@ class ChemicalSRO(BaseFeaturizer):
     Here the calculation is run for each element present in the structure.
 
     A positive f_el indicates the "bonding" with the specific element
-    is favored, at lea the target site;
+    is favored, at least in the target site;
     A negative f_el indicates the "bonding" is not favored, at least
     in the target site.
 
@@ -800,12 +800,13 @@ class ChemicalSRO(BaseFeaturizer):
     def cal_el_amt(structs):
         """
         Identify and "store" the element types and composition of structures,
-        avoiding repeated calculation of composition while featurizing many
+        avoiding repeated calculation of composition when featurizing many
         sites in one structure.
         Args:
-             structs (pandas series): series of pymatgen Structures
+            structs (pandas series): series of pymatgen Structures
         Returns:
-
+            (list of str): elements present in the structures
+            (dict): composition dicts of the structures
         """
         el_amt_dict = {}
         el_list = set()
@@ -823,10 +824,10 @@ class ChemicalSRO(BaseFeaturizer):
         """
         Featurize the dataframe with ChemicalSRO features.
         Args:
-            df (Pandas dataframe): Dataframe containing input data
+            df (pandas dataframe): Dataframe containing input data
             col_id (str or [str]): The dataframe key corresponding to structures
         Returns:
-            (Pandas dataframe) ChemicalSRO-featurized dataframe
+            (pandas dataframe) ChemicalSRO-featurized dataframe
         """
         self.el_list, self.el_amt_dict = self.cal_el_amt(df[col_id[0]])
         df = super(ChemicalSRO, self).\


### PR DESCRIPTION
For ChemicalSRO:
Fix the test problem due to the incompatibility with new featurize_dataframe that call feature_labels before featurize.
Store the composition of each structure to avoid repeated calculation of composition for multiple sites in one structure.