### PR TITLE
Bit of cleanup/standardization for data retrieval

### DIFF
--- a/matminer/data_retrieval/retrieve_Citrine.py
+++ b/matminer/data_retrieval/retrieve_Citrine.py
@@ -48,7 +48,10 @@ class CitrineDataRetrieval:
                       from_record=None, data_set_id=None, max_results=None,
                       show_columns=None):
         """
-        Converts list of json/pifs to a Pandas dataframe
+        Gets a Pandas dataframe object from data retrieved from
+        the Citrine API.  See client docs at
+        http://citrineinformatics.github.io/api-documentation/
+        for more details on input parameters.
 
         Args:
             formula: (str) filter for the chemical formula field; only those

--- a/matminer/data_retrieval/retrieve_Citrine.py
+++ b/matminer/data_retrieval/retrieve_Citrine.py
@@ -21,105 +21,70 @@ def get_value(dict_item):
     if "value" in dict_item:
         return dict_item["value"]
     elif "minimum" in dict_item and "maximum" in dict_item:
-        return "Minimum = {}, Maximum = {}".format(dict_item["minimum"], dict_item["maximum"])
+        return "Minimum = {}, Maximum = {}".format(dict_item["minimum"],
+                                                   dict_item["maximum"])
 
 
 class CitrineDataRetrieval:
+    """
+    CitrineDataRetrieval is used to retrieve data from
+    the Citrination database.  See API client docs at
+    http://citrineinformatics.github.io/api-documentation/
+    """
     def __init__(self, api_key=None):
         """
         Args:
-            api_key: (str) Your Citrine API key, or None if you've set the CITRINE_KEY environment variable
+            api_key: (str) Your Citrine API key, or None if
+                you've set the CITRINE_KEY environment variable
 
         Returns: None
         """
         api_key = api_key if api_key else os.environ["CITRINE_KEY"]
         self.client = CitrinationClient(api_key, "https://citrination.com")
 
-    def get_api_data(self, formula=None, property=None, data_type=None, reference=None, min_measurement=None,
-                      max_measurement=None, from_record=None, data_set_id=None, max_results=None):
-        """
-        Gets data from Citrine in a dataframe format.
-        See client docs at http://citrineinformatics.github.io/api-documentation/ for more details on these parameters.
 
-        Args:
-            formula: (str) filter for the chemical formula field; only those results that have chemical formulas that
-                contain this string will be returned
-            property: (str) name of the property to search for
-            data_type: (str) 'EXPERIMENTAL'/'COMPUTATIONAL'/'MACHINE_LEARNING';
-                filter for properties obtained from experimental work, computational methods, or machine learning.
-            reference: (str) filter for the reference field; only those results that have contributors that contain
-                this string will be returned
-            min_measurement: (str/num) minimum of the property value range
-            max_measurement: (str/num) maximum of the property value range
-            from_record: (int) index of the first record to return (indexed from 0)
-            data_set_id: (int) id of the particular data set to search on
-            max_results: (int) number of records to limit the results to
-
-        Returns: (list) of jsons/pifs returned by Citrine's API
-        """
-
-        json_data = []
-        start = from_record if from_record else 0
-        per_page = 100
-        refresh_time = 3  # seconds to wait between search calls
-
-        while True:
-            if max_results and max_results < per_page:  # use per_page=max_results, eg: in case of max_results=68 < 100
-                pif_query = PifSystemReturningQuery(query=DataQuery(system=PifSystemQuery(
-                    chemical_formula=ChemicalFieldQuery(filter=ChemicalFilter(equal=formula)),
-                    properties=PropertyQuery(name=FieldQuery(filter=Filter(equal=property)),
-                                             value=FieldQuery(filter=Filter(min=min_measurement,
-                                                                            max=max_measurement)),
-                                             data_type=FieldQuery(filter=Filter(equal=data_type))),
-                    references=ReferenceQuery(doi=FieldQuery(filter=Filter(equal=reference)))),
-                    dataset=DatasetQuery(id=Filter(equal=data_set_id))), from_index=start, size=max_results)
-
-            else:
-                pif_query = PifSystemReturningQuery(query=DataQuery(system=PifSystemQuery(
-                    chemical_formula=ChemicalFieldQuery(filter=ChemicalFilter(equal=formula)),
-                    properties=PropertyQuery(name=FieldQuery(filter=Filter(equal=property)),
-                                             value=FieldQuery(filter=Filter(min=min_measurement,
-                                                                            max=max_measurement)),
-                                             data_type=FieldQuery(filter=Filter(equal=data_type))),
-                    references=ReferenceQuery(doi=FieldQuery(filter=Filter(equal=reference)))),
-                    dataset=DatasetQuery(id=Filter(equal=data_set_id))), from_index=start, size=per_page)
-
-            # Check if any results found
-            if "hits" not in self.client.search(pif_query).as_dictionary():
-                raise KeyError("No results found!")
-
-            data = self.client.search(pif_query).as_dictionary()["hits"]
-            size = len(data)
-            start += size
-            json_data.extend(data)
-
-            if max_results and len(json_data) > max_results:                 # check if limit is reached
-                json_data = json_data[:max_results]             # get first multiple of 100 records
-                break
-            if size < per_page:  # break out of last loop of results
-                break
-
-            time.sleep(refresh_time)
-
-        return json_data
-
-    def get_dataframe(self, json_lst, show_columns=None):
+    def get_dataframe(self, formula=None, property=None, data_type=None,
+                      reference=None, min_measurement=None, max_measurement=None,
+                      from_record=None, data_set_id=None, max_results=None,
+                      show_columns=None):
         """
         Converts list of json/pifs to a Pandas dataframe
 
         Args:
-            json_lst: (list) of json/pifs
-            show_columns: (list) list of columns to show from the resulting dataframe
+            formula: (str) filter for the chemical formula field; only those
+                results that have chemical formulas that contain this string
+                will be returned
+            property: (str) name of the property to search for
+            data_type: (str) 'EXPERIMENTAL'/'COMPUTATIONAL'/'MACHINE_LEARNING';
+                filter for properties obtained from experimental work,
+                computational methods, or machine learning.
+            reference: (str) filter for the reference field; only those
+                results that have contributors that contain this string
+                will be returned
+            min_measurement: (str/num) minimum of the property value range
+            max_measurement: (str/num) maximum of the property value range
+            from_record: (int) index of first record to return (indexed from 0)
+            data_set_id: (int) id of the particular data set to search on
+            max_results: (int) number of records to limit the results to
+            show_columns: (list) list of columns to show from the
+                resulting dataframe
 
         Returns: (object) Pandas dataframe object containing the results
 
         """
+        # Get all of the jsons from client
+        jsons = self.get_api_data(
+            formula=formula, property=property, data_type=data_type,
+            reference=reference, min_measurement=min_measurement,
+            max_measurement=max_measurement, from_record=from_record,
+            data_set_id=data_set_id, max_results=max_results)
+
         non_prop_df = pd.DataFrame()  # df w/o measurement column
         prop_df = pd.DataFrame()  # df containing only measurement column
 
         counter = 0  # variable to keep count of sample hit and set indexes
 
-        for hit in tqdm(json_lst):
+        for hit in tqdm(jsons):
 
             counter += 1  # Keep a count to appropriately index the rows
 
@@ -128,7 +93,8 @@ class CitrineDataRetrieval:
                 system_normdf = json_normalize(system_value)
 
                 # Make a DF of all non-'properties' fields
-                non_prop_cols = [cols for cols in system_normdf.columns if "properties" not in cols]
+                non_prop_cols = [cols for cols in system_normdf.columns
+                                 if "properties" not in cols]
                 non_prop_row = pd.DataFrame()
                 for col in non_prop_cols:
                     non_prop_row[col] = system_normdf[col]
@@ -193,3 +159,83 @@ class CitrineDataRetrieval:
             df = df[show_columns]
 
         return df
+
+
+    def get_api_data(self, formula=None, property=None, data_type=None,
+                     reference=None, min_measurement=None, max_measurement=None,
+                     from_record=None, data_set_id=None, max_results=None):
+        """
+        Gets raw api data from Citrine in json format. See client docs
+        at http://citrineinformatics.github.io/api-documentation/
+        for more details on these parameters.
+
+        Args:
+            formula: (str) filter for the chemical formula field; only those
+                results that have chemical formulas that contain this string
+                will be returned
+            property: (str) name of the property to search for
+            data_type: (str) 'EXPERIMENTAL'/'COMPUTATIONAL'/'MACHINE_LEARNING';
+                filter for properties obtained from experimental work,
+                computational methods, or machine learning.
+            reference: (str) filter for the reference field; only those
+                results that have contributors that contain this string
+                will be returned
+            min_measurement: (str/num) minimum of the property value range
+            max_measurement: (str/num) maximum of the property value range
+            from_record: (int) index of first record to return (indexed from 0)
+            data_set_id: (int) id of the particular data set to search on
+            max_results: (int) number of records to limit the results to
+
+        Returns: (list) of jsons/pifs returned by Citrine's API
+        """
+
+        json_data = []
+        start = from_record if from_record else 0
+        per_page = 100
+        refresh_time = 3  # seconds to wait between search calls
+
+        # Construct all of the relevant queries from input args
+        formula_query = ChemicalFieldQuery(filter=ChemicalFilter(equal=formula))
+        prop_query = PropertyQuery(name=FieldQuery(filter=Filter(equal=property)),
+                                   value=FieldQuery(filter=Filter(min=min_measurement,
+                                                                  max=max_measurement)),
+                                   data_type=FieldQuery(filter=Filter(equal=data_type)))
+        ref_query = ReferenceQuery(doi=FieldQuery(filter=Filter(equal=reference)))
+
+        system_query = PifSystemQuery(chemical_formula=formula_query,
+                                      properties=prop_query,
+                                      references=ref_query)
+        dataset_query = DatasetQuery(id=Filter(equal=data_set_id))
+        data_query = DataQuery(system=system_query, dataset=dataset_query)
+
+        while True:
+            # use per_page=max_results, eg: in case of max_results=68 < 100
+            if max_results and max_results < per_page:
+                pif_query = PifSystemReturningQuery(query=data_query,
+                                                    from_index=start,
+                                                    size=max_results)
+            else:
+                pif_query = PifSystemReturningQuery(query=data_query,
+                                                    from_index=start,
+                                                    size=per_page)
+
+            # Check if any results found
+            if "hits" not in self.client.search(pif_query).as_dictionary():
+                raise KeyError("No results found!")
+
+            data = self.client.search(pif_query).as_dictionary()["hits"]
+            size = len(data)
+            start += size
+            json_data.extend(data)
+
+            # check if limit is reached
+            if max_results and len(json_data) > max_results:
+                # get first multiple of 100 records
+                json_data = json_data[:max_results]
+                break
+            if size < per_page:  # break out of last loop of results
+                break
+
+            time.sleep(refresh_time)
+
+        return json_data

--- a/matminer/data_retrieval/retrieve_MDF.py
+++ b/matminer/data_retrieval/retrieve_MDF.py
@@ -18,10 +18,10 @@ class MDFDataRetrieval:
 
     Examples:
         >>>mdf_dr = MDFDataRetrieval(anonymous=True)
-        >>>results = mdf_dr.search(elements=["Ag", "Be"], sources=["oqmd"])
+        >>>results = mdf_dr.get_dataframe(elements=["Ag", "Be"], sources=["oqmd"])
 
-        >>>results = mdf_dr.search(sources=['oqmd'],
-        >>>               match_ranges={"oqmd.band_gap.value": [4.0, "*"]})
+        >>>results = mdf_dr.get_dataframe(sources=['oqmd'],
+        >>>              match_ranges={"oqmd.band_gap.value": [4.0, "*"]})
     """
 
     def __init__(self, anonymous=False, **kwargs):
@@ -41,6 +41,8 @@ class MDFDataRetrieval:
                       exclude_fields=None, match_ranges=None,
                       exclude_ranges=None, unwind_arrays=True):
         """
+        Retrieves data from the MDF API and formats it as
+        a Pandas Dataframe
 
         Args:
             sources ([str]): source names to include, e. g. ["oqmd"]
@@ -99,6 +101,8 @@ class MDFDataRetrieval:
 
     def get_dataframe_by_query(self, query, unwind_arrays=True, **kwargs):
         """
+        Gets a dataframe from the MDF API from an explicit string
+        query (rather than input args like get_dataframe).
 
         Args:
             query (str): String for explicit query
@@ -107,7 +111,7 @@ class MDFDataRetrieval:
             **kwargs: kwargs for query
 
         Returns:
-            aggregated data corresponding to query
+            dataframe corresponding to query
 
         """
         results = self.forge.aggregate(q=query, **kwargs)
@@ -119,7 +123,7 @@ class MDFDataRetrieval:
 #TODO: also might be useful to handle units more intelligently
 def make_dataframe(docs, unwind_arrays=True):
     """
-    Formats raw docs returned from search into a dataframe
+    Formats raw docs returned from MDF API search into a dataframe
 
     Args:
         docs [{}]: list of documents from forge search

--- a/matminer/data_retrieval/retrieve_MDF.py
+++ b/matminer/data_retrieval/retrieve_MDF.py
@@ -24,19 +24,22 @@ class MDFDataRetrieval:
         >>>               match_ranges={"oqmd.band_gap.value": [4.0, "*"]})
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, anonymous=False, **kwargs):
         """
         Args:
+            anonymous (bool): whether to use anonymous login (i. e. no
+                globus authentication)
             **kwargs: kwargs for Forge, including index (globus search index
                 to search on), local_ep, anonymous
         """
 
-        self.forge = Forge(**kwargs)
+        self.forge = Forge(anonymous=anonymous, **kwargs)
 
-    def search(self, sources=None, elements=None, titles=None, tags=None,
-               resource_types=None, match_fields=None, exclude_fields=None,
-               match_ranges=None, exclude_ranges=None, raw=False,
-               unwind_arrays=True):
+
+    def get_dataframe(self, sources=None, elements=None, titles=None,
+                      tags=None, resource_types=None, match_fields=None,
+                      exclude_fields=None, match_ranges=None,
+                      exclude_ranges=None, unwind_arrays=True):
         """
 
         Args:
@@ -91,20 +94,14 @@ class MDFDataRetrieval:
         results = self.forge.aggregate()
 
         # Make into DataFrame
-        if raw:
-            return results
-        else:
-            return make_dataframe(results, unwind_arrays=unwind_arrays)
+        return make_dataframe(results, unwind_arrays=unwind_arrays)
 
 
-    def search_by_query(self, query, unwind_arrays=True,
-                        raw=False, **kwargs):
+    def get_dataframe_by_query(self, query, unwind_arrays=True, **kwargs):
         """
 
         Args:
             query (str): String for explicit query
-            raw (bool): whether or not to return raw (non-dataframe)
-                output, defaults to False
             unwind_arrays (bool): whether or not to unwind arrays in
                 flattening docs for dataframe
             **kwargs: kwargs for query
@@ -114,10 +111,7 @@ class MDFDataRetrieval:
 
         """
         results = self.forge.aggregate(q=query, **kwargs)
-        if raw:
-            return results
-        else:
-            return make_dataframe(results, unwind_arrays=unwind_arrays)
+        return make_dataframe(results, unwind_arrays=unwind_arrays)
 
 
 

--- a/matminer/data_retrieval/tests/test_retrieve_Citrine.py
+++ b/matminer/data_retrieval/tests/test_retrieve_Citrine.py
@@ -13,22 +13,24 @@ pd.set_option('display.max_rows', None)
 citrine_key = os.environ.get('CITRINE_KEY', None)
 
 
-@unittest.skipIf(citrine_key is None, "CITRINE_KEY environment variable not set.")
+@unittest.skipIf(citrine_key is None, "CITRINE_KEY env variable not set.")
 class CitrineDataRetrievalTest(unittest.TestCase):
     def setUp(self):
         self.cdr = CitrineDataRetrieval(citrine_key)
 
     def test_get_data(self):
-        pifs_lst = self.cdr.get_api_data(formula="W", data_type='EXPERIMENTAL', max_results=10)
-        df = self.cdr.get_dataframe(pifs_lst)
-        assert df.shape[0] == 10
+        pifs_lst = self.cdr.get_api_data(formula="W", data_type='EXPERIMENTAL',
+                                         max_results=10)
+        df = self.cdr.get_dataframe(formula='W', data_type='EXPERIMENTAL',
+                                    max_results=10)
+        self.assertEqual(df.shape[0], 10)
 
-    def test_mutiple_items_in_list(self):
-        pifs_lst = self.cdr.get_api_data(data_set_id=114192, max_results=102)
-        df = self.cdr.get_dataframe(pifs_lst)
-        assert df.shape[0] == 102
-        for col in ["Thermal conductivity_5-conditions", "Condition_1", "Thermal conductivity_10"]:
-            assert col in df.columns
+    def test_multiple_items_in_list(self):
+        df = self.cdr.get_dataframe(data_set_id=114192, max_results=102)
+        self.assertEqual(df.shape[0], 102)
+        test_cols = {"Thermal conductivity_5-conditions", "Condition_1",
+                     "Thermal conductivity_10"}
+        self.assertTrue(test_cols < set(df.columns))
 
 
 if __name__ == "__main__":

--- a/matminer/data_retrieval/tests/test_retrieve_MDF.py
+++ b/matminer/data_retrieval/tests/test_retrieve_MDF.py
@@ -19,21 +19,21 @@ class MDFDataRetrievalTest(unittest.TestCase):
     def setUpClass(cls):
         cls.mdf_dr = MDFDataRetrieval(anonymous=True)
 
-    def test_search(self):
-        results = self.mdf_dr.search(sources=['oqmd'],
-                                     elements=["Ag", "Be", "V"],
-                                     unwind_arrays=False)
+    def test_get_dataframe(self):
+        results = self.mdf_dr.get_dataframe(sources=['oqmd'],
+                                            elements=["Ag", "Be", "V"],
+                                            unwind_arrays=False)
         for elts in results['mdf.elements']:
             self.assertTrue("Be" in elts)
             self.assertTrue("Ag" in elts)
             self.assertTrue("V" in elts)
 
 
-    def test_search_by_query(self):
+    def test_get_dataframe_by_query(self):
         qstring = "(mdf.source_name:oqmd) AND "\
                   "(mdf.elements:Si AND mdf.elements:V AND "\
                   "oqmd.band_gap.value:[0.5 TO *])"
-        results = self.mdf_dr.search_by_query(qstring, unwind_arrays=False)
+        results = self.mdf_dr.get_dataframe_by_query(qstring, unwind_arrays=False)
         self.assertTrue(all(results['oqmd.band_gap.value'] > 0.5))
         for elts in results['mdf.elements']:
             self.assertTrue("Si" in elts)


### PR DESCRIPTION
In the process of refactoring tutorials, found that there was some inconsistency in the data retrieval tools.  This PR resolves some of that, and includes a bit of cleanup.  The primary thing is that each data retrieval tool has a "get_dataframe" method that interfaces directly to the data retrieval API.  I think there could still be more uniformity on these methods, but that'll have to be a TODO for now.