### PR TITLE
WIP: Refactor BaseFeaturizer

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -54,10 +54,10 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     running one operation should not affect the output of another.
 
     All options of the featurizer must be set by the `__init__` function. All options must
-    be listed as keyword arguments, and the value must be saved as a class attribute with
-    the same name (e.g., argument `n` should be stored in `self.n`). These requirements
-    are necessary for compatibility with the `get_params` and `set_params` methods
-    of `BaseEstimator`.
+    be listed as keyword arguments with default values, and the value must be saved as a
+    class attribute with the same name (e.g., argument `n` should be stored in `self.n`).
+    These requirements are necessary for compatibility with the `get_params` and `set_params`
+    methods of `BaseEstimator`, which enable easy interoperability with scikit-learn.
 
     Depending on the complexity of your featurizer, it may be worthwhile to implement a
     `from_preset` class method. The `from_preset` method takes the name of a preset and
@@ -68,9 +68,35 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     must be set for the featurizer to work. Any variables that are set by fitting should be stored
     as class attributes that end with an underscore. (This follows the pattern used by
     scikit-learn).
+
+    Another implementation to consider is whether it is worth making any utility operations
+    for your featurizer. `featurize` must return a list of features, but this may not be the most
+    natural representation for your features (e.g., a `dict` could be better). Making a separate
+    function for computing features in this natural representation and having the `featurize` function
+    call this method and then convert the data into a list is a recommended approach. Users who want
+    to compute the representation in the natural form can use the utility function and users who
+    want the data in a ML-ready format (list) can call `featurize`. See `PartialRadialDistributionFunction`
+    for an example of this concept.
+
+    ## Documenting a BaseFeaturizer
+
+    The class documentation for each featurizer must contain a description of the options and
+    the features that will be computed. The options of the class must all be defined in the
+    `__init__` function of the class, and we recommend documenting them using the
+    [Google style](https://google.github.io/styleguide/pyguide.html).
+
+    We recommend starting the class documentation with a high-level overview of the features.
+    For example, mention what kind of characteristics of the material they describe and refer
+    the reader to a paper that describes these features well (use a hyperlink if possible, so
+    that the readthedocs will like to that paper). Then, describe each of the individual feautres
+    in a block named "Features". It is necessary here to give the user enough information for user
+    to map a feature name what it means. The objective in this part is to allow people to
+    understand what each column of their dataframe is without having to read the Python code.
+    You do not need to explain all of the math/algorithms behind each feature for them to be
+    able to reproduce the feature, just to get an idea what it is.
     """
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, **fit_kwargs):
         """Update the parameters of this featurizer based on available data
 
         Args:

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -794,7 +794,7 @@ class ChemicalSRO(BaseFeaturizer):
         return list(el_list), el_amt_dict
 
     def featurize_dataframe(self, df, col_id, ignore_errors=True,
-                            inplace=True, n_jobs=1):
+                            inplace=True):
         """
         Featurize the dataframe with ChemicalSRO features.
         Args:
@@ -807,8 +807,7 @@ class ChemicalSRO(BaseFeaturizer):
         df = super(ChemicalSRO, self).\
              featurize_dataframe(df, col_id,
                                  ignore_errors=ignore_errors,
-                                 inplace=inplace,
-                                 n_jobs=n_jobs)
+                                 inplace=inplace)
         delattr(self, 'el_list')
         delattr(self, 'el_amt_dict')
         return df

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -191,15 +191,14 @@ class PartialRadialDistributionFunction(BaseFeaturizer):
            distances. For example, "Al-Al PRDF r=1.00-1.50" corresponds
            to the density of Al-Al bonds between 1 and 1.5 distance units
            By default, this featurizer generates RDFs for each pair
-           of elements in the training set. 
-    """
+           of elements in the training set."""
 
     def __init__(self, cutoff=20.0, bin_size=0.1):
         self.cutoff = cutoff
         self.bin_size = bin_size
         self.elements_ = None
 
-    def fit(self, X, y=None, include_elems=list(), exclude_elems=list()):
+    def fit(self, X, y=None, include_elems=(), exclude_elems=()):
         """Define the list of elements to be included in the PRDF. By default,
         the PRDF will include all of the elements in `X`
 
@@ -216,7 +215,7 @@ class PartialRadialDistributionFunction(BaseFeaturizer):
 
         # Get all of elements that appaer
         for strc, in X:
-            elements.update([e.element if isinstance(e,Specie) else e for e in strc.composition.keys()])
+            elements.update([e.element if isinstance(e, Specie) else e for e in strc.composition.keys()])
 
         # Remove the elements excluded by the user
         elements.difference_update([Element(e) for e in exclude_elems])

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -62,7 +62,6 @@ class TestBaseClass(PymatgenTest):
         self.multi = MultipleFeatureFeaturizer()
         self.matrix = MatrixFeaturizer()
         self.multiargs = SingleFeaturizerMultiArgs()
-        self.n_jobs = 2
 
     @staticmethod
     def make_test_data():
@@ -120,12 +119,14 @@ class TestBaseClass(PymatgenTest):
 
         # Single argument
         s = self.single
-        mat = s.featurize_many([1, 2, 3], self.n_jobs)
+        s.set_n_jobs(2)
+        mat = s.featurize_many([1, 2, 3])
         self.assertArrayAlmostEqual(mat, [[2], [3], [4]])
 
         # Multi-argument
         s = self.multiargs
-        mat = s.featurize_many([[1, 4], [2, 5], [3, 6]], self.n_jobs)
+        s.set_n_jobs(2)
+        mat = s.featurize_many([[1, 4], [2, 5], [3, 6]])
         self.assertArrayAlmostEqual(mat, [[5], [7], [9]])
 
     def test_multiprocessing_df(self):
@@ -133,14 +134,16 @@ class TestBaseClass(PymatgenTest):
         # Single argument
         s = self.single
         data = self.make_test_data()
-        data = s.featurize_dataframe(data, 'x', n_jobs=self.n_jobs)
+        s.set_n_jobs(2)
+        data = s.featurize_dataframe(data, 'x')
         self.assertArrayAlmostEqual(data['y'], [2, 3, 4])
 
         # Multi-argument
         s = self.multiargs
         data = self.make_test_data()
+        s.set_n_jobs(2)
         data['x2'] = [4, 5, 6]
-        data = s.featurize_dataframe(data, ['x', 'x2'], n_jobs=self.n_jobs)
+        data = s.featurize_dataframe(data, ['x', 'x2'])
         self.assertArrayAlmostEqual(data['y'], [5, 7, 9])
 
 

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -144,38 +144,66 @@ class StructureFeaturesTest(PymatgenTest):
         # Test a few peaks in diamond
         # These expected numbers were derived by performing
         # the calculation in another code
-        prdf = PartialRadialDistributionFunction().featurize(self.diamond)[0]
+        distances, prdf = PartialRadialDistributionFunction().compute_prdf(self.diamond)
         self.assertEqual(len(prdf.values()), 1)
-        self.assertAlmostEqual(
-            prdf[('C', 'C')]['distribution'][int(round(1.4 / 0.1))], 0)
-        self.assertAlmostEqual(
-            prdf[('C', 'C')]['distribution'][int(round(1.5 / 0.1))], 1.32445167622)
-        self.assertAlmostEqual(max(prdf[('C', 'C')]['distances']), 20.0)
-        self.assertAlmostEqual(
-            prdf[('C', 'C')]['distribution'][int(round(19.9 / 0.1))], 0.07197902)
+        self.assertAlmostEqual(prdf[('C', 'C')][int(round(1.4 / 0.1))], 0)
+        self.assertAlmostEqual(prdf[('C', 'C')][int(round(1.5 / 0.1))], 1.32445167622)
+        self.assertAlmostEqual(max(distances), 20.0)
+        self.assertAlmostEqual(prdf[('C', 'C')][int(round(19.9 / 0.1))], 0.07197902)
 
         # Test a few peaks in CsCl, make sure it gets all types correctly
-        prdf = PartialRadialDistributionFunction(cutoff=10).featurize(
-            self.cscl)[0]
+        distances, prdf = PartialRadialDistributionFunction(cutoff=10).compute_prdf(self.cscl)
         self.assertEqual(len(prdf.values()), 4)
-        self.assertAlmostEqual(max(prdf[('Cs', 'Cl')]['distances']), 10.0)
-        self.assertAlmostEqual(
-            prdf[('Cs', 'Cl')]['distribution'][int(round(3.6 / 0.1))], 0.477823197)
-        self.assertAlmostEqual(
-            prdf[('Cl', 'Cs')]['distribution'][int(round(3.6 / 0.1))], 0.477823197)
-        self.assertAlmostEqual(
-            prdf[('Cs', 'Cs')]['distribution'][int(round(3.6 / 0.1))], 0)
+        self.assertAlmostEqual(max(distances), 10.0)
+        self.assertAlmostEqual(prdf[('Cs', 'Cl')][int(round(3.6 / 0.1))], 0.477823197)
+        self.assertAlmostEqual(prdf[('Cl', 'Cs')][int(round(3.6 / 0.1))], 0.477823197)
+        self.assertAlmostEqual(prdf[('Cs', 'Cs')][int(round(3.6 / 0.1))], 0)
 
         # Do Ni3Al, make sure it captures the antisymmetry of Ni/Al sites
-        prdf = PartialRadialDistributionFunction(
-            cutoff=10, bin_size=0.5).featurize(self.ni3al)[0]
+        distances, prdf = PartialRadialDistributionFunction(cutoff=10, bin_size=0.5)\
+            .compute_prdf(self.ni3al)
         self.assertEqual(len(prdf.values()), 4)
-        self.assertAlmostEqual(
-            prdf[('Ni', 'Al')]['distribution'][int(round(2 / 0.5))], 0.125236677)
-        self.assertAlmostEqual(
-            prdf[('Al', 'Ni')]['distribution'][int(round(2 / 0.5))], 0.37571003)
-        self.assertAlmostEqual(
-            prdf[('Al', 'Al')]['distribution'][int(round(2 / 0.5))], 0)
+        self.assertAlmostEqual(prdf[('Ni', 'Al')][int(round(2 / 0.5))], 0.125236677)
+        self.assertAlmostEqual(prdf[('Al', 'Ni')][int(round(2 / 0.5))], 0.37571003)
+        self.assertAlmostEqual(prdf[('Al', 'Al')][int(round(2 / 0.5))], 0)
+
+        # Check the fit operation
+        featurizer = PartialRadialDistributionFunction()
+        featurizer.fit(zip([self.diamond, self.cscl, self.ni3al]))
+        self.assertEquals({'Cs', 'Cl', 'C', 'Ni', 'Al'}, set(featurizer.elements_))
+
+        featurizer.fit(zip([self.diamond, self.cscl, self.ni3al]), exclude_elems=['Cs', 'Al'])
+        self.assertEquals({'Cl', 'C', 'Ni'}, set(featurizer.elements_))
+
+        featurizer.fit(zip([self.diamond, self.cscl, self.ni3al]), exclude_elems=['Cs', 'Al'],
+                       include_elems=['H'])
+        self.assertEquals({'H', 'Cl', 'C', 'Ni'}, set(featurizer.elements_))
+
+        # Check the feature labels
+        featurizer.elements_ = ['Al', 'Ni']
+        labels = featurizer.feature_labels()
+        n_bins = len(featurizer._make_bins()) - 1
+
+        self.assertEquals(3 * n_bins, len(labels))
+        self.assertIn('Al-Ni PRDF r=0.00-0.10', labels)
+
+        # Check the featurize method
+        featurizer.elements_ = ['C']
+        features = featurizer.featurize(self.diamond)
+        prdf = featurizer.compute_prdf(self.diamond)[1]
+        self.assertArrayAlmostEqual(features, prdf[('C', 'C')])
+
+        # Make sure labels and features are in the same order
+        featurizer.elements_ = ['Al', 'Ni']
+        features = featurizer.featurize(self.ni3al)
+        labels = featurizer.feature_labels()
+        prdf = featurizer.compute_prdf(self.ni3al)[1]
+        self.assertEquals((n_bins * 3,), features.shape)
+        self.assertTrue(labels[0].startswith('Al-Al'))
+        self.assertTrue(labels[n_bins].startswith('Al-Ni'))
+        self.assertTrue(labels[2 * n_bins].startswith('Ni-Ni'))
+        self.assertArrayAlmostEqual(features, np.hstack(
+            [prdf[('Al', 'Al')], prdf[('Al', 'Ni')], prdf[('Ni', 'Ni')]]))
 
     def test_redf(self):
         d = ElectronicRadialDistributionFunction().featurize(

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ citrination-client==3.0.0
 plotly==2.0.12
 future==0.16.0
 mdf_forge==0.5.1
+scikit_learn==0.19.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         install_requires=['pymatgen>=2018.2.13', 'tqdm>=4.14.0', 'pandas>=0.20.1',
                           'pymongo>=3.4.0', 'pint>=0.8.1', 'six>=1.10.0',
                           'citrination-client>=2.1.0', 'plotly>=2.0.12',
-                          'mdf_forge>=0.5.1'],
+                          'mdf_forge>=0.5.1', 'scikit-learn>=0.19.0'],
         extras_require={'mpds': ['jmespath>=0.9.3', 'ujson>=1.35', 'httplib2>=0.10.3', 'ase>=3.14.1'],
                         'plot': ['matplotlib>=2.0.0']},
         classifiers=['Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Introduces a draft BaseFeaturizer class (discussion in #135) that follows the API for scikit-learn's Transformer classes. 

I also implemented PartialRadialDistributionFunction as an example, and wrote some documentation on how to implement a BaseFeaturizer.

A few questions and issues that I already have:

- Is it a problem that we have both `transform` and `featurize_many`? I kept both because featurize_many provides the parallelism and error-handling options, and the `transform` API from scikit-learn does not support any additional `kwargs`. `transform` is a restricted wrapper over `featurize_many`.

- Parallelism and `transform`: Sklearn classes generally support parallelism by including a `n_jobs` class attribute. Adding `n_jobs` to the initialize means all new subclasses should include `n_jobs` in their kwargs and call the base classes's constructor. I'm in favor of doing this. 

- Does it make sense to put the implementation guide I wrote in the class documentation for BaseFeaturizer? 

To do list:

- Adjust all classes that override `featurize_dataframe` to use this new class. (They probably benefit from the `fit` operation)
- Write a guide for documenting the features which each featurizer generates. I think we should have a standard way for doing this.