### PR TITLE
Fix cohesive energy test 

### DIFF
--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -910,7 +910,7 @@ class CohesiveEnergy(BaseFeaturizer):
         cohesive_energy = -formation_energy_per_atom * comp.num_atoms
         for el in el_amt_dict:
             cohesive_energy += el_amt_dict[el] * \
-                               CohesiveEnergyData().get_property(el)
+                               CohesiveEnergyData().get_elemental_property(el)
 
         cohesive_energy_per_atom = cohesive_energy / comp.num_atoms
 


### PR DESCRIPTION
Cohesive energy test failed when not skipped (it ran fine on CircleCI bc skipped if MP API key was set) and didn't work otherwise. This fixes it


if tests still pass on circleci ill just merge