### PR TITLE
add DopingFermi: a Dos featurizer + unittest

### DIFF
--- a/matminer/featurizers/tests/test_dos.py
+++ b/matminer/featurizers/tests/test_dos.py
@@ -5,7 +5,7 @@ import os
 import pandas as pd
 import unittest
 
-from matminer.featurizers.dos import DOSFeaturizer
+from matminer.featurizers.dos import DOSFeaturizer, DopingFermi
 from pymatgen.electronic_structure.dos import CompleteDos
 from pymatgen.util.testing import PymatgenTest
 
@@ -37,6 +37,16 @@ class DOSFeaturesTest(PymatgenTest):
         self.assertEqual(df_df['vbm_specie_1'][0], 'Si')
         self.assertEqual(df_df['vbm_character_1'][0], 'p')
         self.assertEqual(df_df['vbm_nsignificant'][0], 2)
+
+    def test_DopingFermi(self):
+        dopings = [-1e18, -1e20, 1e18, 1e20]
+        df = DopingFermi(dopings=dopings, eref="midgap", return_eref=True
+                         ).featurize_dataframe(self.df, col_id=['dos'])
+        self.assertAlmostEqual(df['fermi_c-1e+18T300'][0], 6.138458, places=4)
+        self.assertAlmostEqual(df['fermi_c-1e+20T300'][0], 6.258075, places=4)
+        self.assertAlmostEqual(df['fermi_c1e+18T300'][0], 5.497809, places=4)
+        self.assertAlmostEqual(df['fermi_c1e+20T300'][0], 5.37833, places=4)
+        self.assertAlmostEqual(df['midgap eref'][0], 5.8162, places=4)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
this featurizer returns the fermi levels that result in the input doping levels (at a given temperature). This fermi is calculated solely based on pymatgen DosFermi object or any pmg Dos object that has the structure attribute.

the tests are expected to fail until a new version of pymatgen is released. I did not try  @unittest.expectedFailure decorator as I am importing DopingFermi at the beginning of the test and DopingFermi class is not available in the latest pymatgen so the test would fail even with the decorator.