### PR TITLE
MultiFeaturizer handle 1D arrays w/ and w/o singlton dimensions

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -338,7 +338,7 @@ class MultipleFeaturizer(BaseFeaturizer):
         self.featurizers = featurizers
 
     def featurize(self, *x):
-        return np.hstack(f.featurize(*x) for f in self.featurizers)
+        return np.hstack(np.squeeze(f.featurize(*x)) for f in self.featurizers)
 
     def feature_labels(self):
         return sum([f.feature_labels() for f in self.featurizers], [])


### PR DESCRIPTION
Makes MultiFeaturizer more robust to how the underlying featurizers represent 1D arrays. If the classes each use a different method (e.g., shape of (4,1) vs shape == (4,)), MultiFeaturizer errors with a vague `ValueError: all the input arrays must have same number of dimensions`. This PR prevents this error, and includes a new unittest for catching this bug.