### PR TITLE
Sort out reference for cohesive energies

### DIFF
--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -938,9 +938,7 @@ class CohesiveEnergy(BaseFeaturizer):
         return ["Saurabh Bajaj", "Anubhav Jain"]
 
     def citations(self):
-        # TODO: @sbajaj unclear whether cohesive energies are taken from first ref, second ref, or combination of both
-        return [
-            "@misc{ url = {http://www.knowledgedoor.com/2/elements_handbook/cohesive_energy.html}}"]
+        return ["@misc{ url = {http://www.knowledgedoor.com/2/elements_handbook/cohesive_energy.html}}"]
 
 
 class Miedema(BaseFeaturizer):

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -941,7 +941,7 @@ class CohesiveEnergy(BaseFeaturizer):
         # TODO: @sbajaj unclear whether cohesive energies are taken from first ref, second ref, or combination of both
         return [
             "@misc{, title = {{Knowledgedoor Cohesive energy handbook}}, "
-            "url = {http://www.knowledgedoor.com/2/elements{\_}handbook/cohesive{\_}energy.html}}",
+            "url = {http://www.knowledgedoor.com/2/elements_handbook/cohesive_energy.html}}",
             "@book{Kittel, author = {Kittel, C}, isbn = {978-0-471-41526-8}, "
             "publisher = {Wiley}, title = {{Introduction to Solid State "
             "Physics, 8th Edition}}, year = {2005}}"]

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -940,11 +940,7 @@ class CohesiveEnergy(BaseFeaturizer):
     def citations(self):
         # TODO: @sbajaj unclear whether cohesive energies are taken from first ref, second ref, or combination of both
         return [
-            "@misc{, title = {{Knowledgedoor Cohesive energy handbook}}, "
-            "url = {http://www.knowledgedoor.com/2/elements_handbook/cohesive_energy.html}}",
-            "@book{Kittel, author = {Kittel, C}, isbn = {978-0-471-41526-8}, "
-            "publisher = {Wiley}, title = {{Introduction to Solid State "
-            "Physics, 8th Edition}}, year = {2005}}"]
+            "@misc{ url = {http://www.knowledgedoor.com/2/elements_handbook/cohesive_energy.html}}"]
 
 
 class Miedema(BaseFeaturizer):

--- a/matminer/utils/data.py
+++ b/matminer/utils/data.py
@@ -98,9 +98,8 @@ class OxidationStateDependentData(AbstractData):
 
 
 class CohesiveEnergyData(AbstractData):
-    """Get the cohesive energy of an element.
-
-    TODO: Where is this data from? -wardlt
+    """
+    Get the cohesive energy of an element.
     """
 
     def __init__(self):

--- a/matminer/utils/data.py
+++ b/matminer/utils/data.py
@@ -100,6 +100,7 @@ class OxidationStateDependentData(AbstractData):
 class CohesiveEnergyData(AbstractData):
     """
     Get the cohesive energy of an element.
+     Ref: KnowledgeDoor at http://www.knowledgedoor.com/2/elements_handbook/cohesive_energy.html
     """
 
     def __init__(self):


### PR DESCRIPTION
To resolve #145 . 
I used KnowledgeDoor to get the cohesive energies, which in turn got the data from Kittle. 
Since Kittle is already reference on KnowledgeDoor, I remove it from the citation here. 