### PR TITLE
Function featurize

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -365,8 +365,10 @@ class MultipleFeaturizer(BaseFeaturizer):
     def featurize_dataframe(self, df, col_id, ignore_errors=False,
                             return_errors=False, inplace=True):
         for f in self.featurizers:
+            f.set_n_jobs(1)
             df = f.featurize_dataframe(df, col_id, ignore_errors,
                                        return_errors, inplace)
+            df[f.feature_labels()] = df[f.feature_labels()].applymap(np.squeeze)
         return df
 
     def citations(self):

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -368,10 +368,24 @@ class MultipleFeaturizer(BaseFeaturizer):
 
     def featurize_dataframe(self, df, col_id, ignore_errors=False,
                             return_errors=False, inplace=True):
-        for f in self.featurizers:
-            df = f.featurize_dataframe(df, col_id, ignore_errors,
-                                       return_errors, inplace)
-            df[f.feature_labels()] = df[f.feature_labels()].applymap(np.squeeze)
+        """
+        Featurize dataframe is overloaded in order to allow
+        compatibility with Featurizers that overload featurize_dataframe
+        """
+        # Detect if any featurizers override featurize_dataframe
+        override = ["featurize_dataframe" in f.__class__.__dict__.keys()
+                    for f in self.featurizers]
+        if any(override):
+            warnings.warn(
+                "One or more featurizers overrides featurize_dataframe, "
+                "featurization will be sequential and may diminish performance")
+            for f in self.featurizers:
+                df = f.featurize_dataframe(df, col_id, ignore_errors,
+                                           return_errors, inplace)
+                df[f.feature_labels()] = df[f.feature_labels()].applymap(np.squeeze)
+        else:
+            df = super(self, MultipleFeaturizer).featurize_dataframe(
+                df, col_id, ignore_errors, return_errors, inplace)
         return df
 
     def citations(self):

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -181,7 +181,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
             col_id = [col_id]
 
         # Generate the feature labels
-        labels = self.feature_labels()
+        labels = self.generate_feature_columns(col_id)
 
         # Check names to avoid overwriting the current columns
         for col in df.columns.values:
@@ -340,6 +340,21 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
         raise NotImplementedError("implementors() is not defined!")
 
+    def generate_feature_columns(self, col_id):
+        """
+        Function that returns new feature columns ids, exists primarily
+        so any method which needs to modify new column names based on
+        input column identity can do so without altering feature_labels,
+        by default this will simply return feature_labels()
+
+        Args:
+            col_id ([str]): input column ids
+
+        Returns:
+            list of column labels
+        """
+        return self.feature_labels()
+
 
 class MultipleFeaturizer(BaseFeaturizer):
     """
@@ -361,6 +376,9 @@ class MultipleFeaturizer(BaseFeaturizer):
 
     def feature_labels(self):
         return sum([f.feature_labels() for f in self.featurizers], [])
+
+    def generate_feature_columns(self, col_id):
+        return sum([f.generate_feature_columns(col_id) for f in self.featurizers], [])
 
     def citations(self):
         return list(set(sum([f.citations() for f in self.featurizers], [])))

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -384,7 +384,7 @@ class MultipleFeaturizer(BaseFeaturizer):
                                            return_errors, inplace)
                 df[f.feature_labels()] = df[f.feature_labels()].applymap(np.squeeze)
         else:
-            df = super(self, MultipleFeaturizer).featurize_dataframe(
+            df = super(MultipleFeaturizer, self).featurize_dataframe(
                 df, col_id, ignore_errors, return_errors, inplace)
         return df
 

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -362,9 +362,6 @@ class MultipleFeaturizer(BaseFeaturizer):
     def feature_labels(self):
         return sum([f.feature_labels() for f in self.featurizers], [])
 
-    def generate_feature_columns(self, col_id):
-        return sum([f.generate_feature_columns(col_id) for f in self.featurizers], [])
-
     def citations(self):
         return list(set(sum([f.citations() for f in self.featurizers], [])))
 

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -181,7 +181,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
             col_id = [col_id]
 
         # Generate the feature labels
-        labels = self.generate_feature_columns(col_id)
+        labels = self.feature_labels()
 
         # Check names to avoid overwriting the current columns
         for col in df.columns.values:
@@ -339,21 +339,6 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
         """
 
         raise NotImplementedError("implementors() is not defined!")
-
-    def generate_feature_columns(self, col_id):
-        """
-        Function that returns new feature columns ids, exists primarily
-        so any method which needs to modify new column names based on
-        input column identity can do so without altering feature_labels,
-        by default this will simply return feature_labels()
-
-        Args:
-            col_id ([str]): input column ids
-
-        Returns:
-            list of column labels
-        """
-        return self.feature_labels()
 
 
 class MultipleFeaturizer(BaseFeaturizer):

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -359,13 +359,16 @@ class MultipleFeaturizer(BaseFeaturizer):
     def featurize(self, *x):
         return np.hstack(np.squeeze(f.featurize(*x)) for f in self.featurizers)
 
+    def set_n_jobs(self, n_jobs):
+        for f in self.featurizers:
+            f.set_n_jobs(n_jobs)
+
     def feature_labels(self):
         return sum([f.feature_labels() for f in self.featurizers], [])
 
     def featurize_dataframe(self, df, col_id, ignore_errors=False,
                             return_errors=False, inplace=True):
         for f in self.featurizers:
-            f.set_n_jobs(1)
             df = f.featurize_dataframe(df, col_id, ignore_errors,
                                        return_errors, inplace)
             df[f.feature_labels()] = df[f.feature_labels()].applymap(np.squeeze)

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -185,7 +185,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
         # Check names to avoid overwriting the current columns
         for col in df.columns.values:
-            if labels and col in labels:
+            if col in labels:
                 raise ValueError('"{}" exists in input dataframe'.format(col))
 
         # Compute the features
@@ -361,6 +361,13 @@ class MultipleFeaturizer(BaseFeaturizer):
 
     def feature_labels(self):
         return sum([f.feature_labels() for f in self.featurizers], [])
+
+    def featurize_dataframe(self, df, col_id, ignore_errors=False,
+                            return_errors=False, inplace=True):
+        for f in self.featurizers:
+            df = f.featurize_dataframe(df, col_id, ignore_errors,
+                                       return_errors, inplace)
+        return df
 
     def citations(self):
         return list(set(sum([f.citations() for f in self.featurizers], [])))

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -119,10 +119,9 @@ class FunctionFeaturizer(BaseFeaturizer):
         as the base class
 
         Args:
-            df (Pandas dataframe): Dataframe containing input data.
+            df (pandas.DataFrame): Dataframe containing input data.
             col_id (str or list of str): column label containing objects to
-                featurize. Can be multiple labels if the featurize function
-                requires multiple inputs.
+                featurize.
             ignore_errors (bool): Returns NaN for dataframe rows where
                 exceptions are thrown if True. If False, exceptions
                 are thrown as normal.
@@ -132,7 +131,7 @@ class FunctionFeaturizer(BaseFeaturizer):
             inplace (bool): Whether to add new columns to input dataframe (df)
 
         Returns:
-            updated dataframe.
+            updated DataFrame.
         """
         self.fit(col_id)
         return super(FunctionFeaturizer, self).featurize_dataframe(

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -5,10 +5,12 @@ from sympy.parsing.sympy_parser import parse_expr
 import sympy as sp
 import itertools
 from six import string_types
+from pandas import DataFrame, Series
 
 from collections import OrderedDict
 
 from matminer.featurizers.base import BaseFeaturizer
+from sklearn.exceptions import NotFittedError
 
 
 # Default expressions to include in function featurizer
@@ -95,6 +97,9 @@ class FunctionFeaturizer(BaseFeaturizer):
         Returns:
             Set of feature labels corresponding to expressions
         """
+        if not self._feature_labels:
+            raise NotFittedError("Feature labels is only set if data is fitted"
+                                 " to a dataframe")
         return self._feature_labels
 
     def fit(self, X, y=None, **fit_kwargs):

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -74,43 +74,6 @@ class FunctionFeaturizer(BaseFeaturizer):
                                                    self.combo_function))
              for n in range(1, self.multi_feature_depth+1)])
 
-    def featurize_dataframe(self, df, col_id, ignore_errors=False,
-                            return_errors=False, inplace=True):
-        """
-        Compute features for all entries contained in input dataframe.
-
-        Args:
-            df (DataFrame): dataframe containing input data
-            col_id (str or list of str): column label containing objects
-                to featurize, can be single or multiple column names
-            ignore_errors (bool): Returns NaN for dataframe rows where
-                exceptions are thrown if True. If False, exceptions
-                are thrown as normal.
-            return_errors (bool). Returns the errors encountered for each
-                row in a separate `XFeaturizer errors` column if True. Requires
-                ignore_errors to be True.
-            inplace (bool): Whether to add new columns to input dataframe (df)
-
-        Returns:
-            updated DataFrame
-
-        """
-        # Generate new dataframe out-of-place
-        new_df = super(FunctionFeaturizer, self).featurize_dataframe(
-            df, col_id, ignore_errors=ignore_errors,
-            return_errors=return_errors, inplace=False)
-
-        # Generate and add new columns names
-        new_col_names = self.generate_string_expressions(col_id)
-        new_df.columns = df.columns.tolist() + new_col_names
-
-        if inplace:
-            for k in new_col_names:
-                df[k] = new_df[k]
-            return df
-        else:
-            return new_df
-
     def featurize(self, *args):
         """
         Main featurizer function, essentially iterates over all
@@ -132,6 +95,13 @@ class FunctionFeaturizer(BaseFeaturizer):
             Set of feature labels corresponding to expressions
         """
         return None
+
+    def generate_feature_columns(self, col_id):
+        """
+        Returns:
+            Set of feature labels corresponding to expressions
+        """
+        return self.generate_string_expressions(col_id)
 
     def generate_string_expressions(self, input_variable_names):
         """

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -136,7 +136,7 @@ class FunctionFeaturizer(BaseFeaturizer):
         """
         self.fit(col_id)
         return super(FunctionFeaturizer, self).featurize_dataframe(
-            df, col_id, ignore_errors=False, return_errors=False, inplace=True)
+            df, col_id, ignore_errors, return_errors, inplace)
 
     def fit_featurize_dataframe(self, df, col_id, *args, **kwargs):
         """

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -141,29 +141,9 @@ class FunctionFeaturizer(BaseFeaturizer):
         Returns:
             updated DataFrame.
         """
-        self.fit(col_id)
+        self.fit(df[col_id])
         return super(FunctionFeaturizer, self).featurize_dataframe(
             df, col_id, ignore_errors, return_errors, inplace)
-
-    def fit_featurize_dataframe(self, df, col_id, *args, **kwargs):
-        """
-        The dataframe equivalent of fit_transform. Takes a dataframe and
-        column id as input, fits the featurizer to that dataframe, and
-        returns a featurized dataframe. Accepts the same arguments as
-        featurize_dataframe.  Note that it's overridden in FunctionFeaturizer
-        because the fit method doesn't take dataframe data, but dataframe
-        labels instead.
-
-        Args:
-            df (Pandas dataframe): Dataframe containing input data.
-            col_id (str or list of str): column label containing objects to
-                featurize. Can be multiple labels if the featurize function
-                requires multiple inputs.
-
-        Returns:
-            updated dataframe based on featurizer fitted to that dataframe.
-        """
-        return self.featurize_dataframe(df, col_id, *args, **kwargs)
 
     def generate_string_expressions(self, input_variable_names):
         """

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -43,7 +43,8 @@ class FunctionFeaturizer(BaseFeaturizer):
         combo_function (function): function to combine multi-features,
             defaults to np.prod (i.e. cumulative product of expressions),
             note that a combo function must cleanly process sympy
-            expressions
+            expressions and **takes a list of arbitrary length as input**,
+            other options include np.sum
         latexify_labels (bool): whether to render labels in latex,
             defaults to False
     """

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -108,12 +108,15 @@ class FunctionFeaturizer(BaseFeaturizer):
         only intended to be invoked as part of featurize_dataframe
 
         Args:
-            X ([str]): list of feature labels
+            X (DataFrame or array-like): data to fit to
 
         Returns:
             Set of feature labels corresponding to expressions
         """
-        self._feature_labels = self.generate_string_expressions(X)
+        if isinstance(X, DataFrame):
+            self._feature_labels = self.generate_string_expressions(X.columns)
+        elif isinstance(X, Series):
+            self._feature_labels = self.generate_string_expressions(X.name)
         return self
 
     def featurize_dataframe(self, df, col_id, ignore_errors=False,

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -56,6 +56,17 @@ class MatrixFeaturizer(BaseFeaturizer):
         return ["Everyone"]
 
 
+class MultiArgs2(SingleFeaturizerMultiArgs):
+    def featurize(self, *x):
+        # Making a 2D array to test whether MutliFeaturizer
+        #  can handle featurizers that have both 1D vectors with
+        #  singleton dimensions (e.g., shape==(4,1)) and those
+        #  without (e.g., shape==(4,))
+        return [super(MultiArgs2, self).featurize(*x)]
+
+    def feature_labels(self):
+        return ['y2']
+
 class FittableFeaturizer(BaseFeaturizer):
     """
     This test featurizer tests fitting qualities of BaseFeaturizer, including
@@ -142,22 +153,10 @@ class TestBaseClass(PymatgenTest):
         data = self.make_test_data()
         data['x2'] = [4, 5, 6]
 
-        # Create a second featurizer
-        class MultiArgs2(SingleFeaturizerMultiArgs):
-            def featurize(self, *x):
-                # Making a 2D array to test whether MutliFeaturizer
-                #  can handle featurizers that have both 1D vectors with
-                #  singleton dimensions (e.g., shape==(4,1)) and those
-                #  without (e.g., shape==(4,))
-                return [super(MultiArgs2, self).featurize(*x)]
-
-            def feature_labels(self):
-                return ['y2']
         multiargs2 = MultiArgs2()
 
         # Create featurizer
         multi_f = MultipleFeaturizer([self.multiargs, multiargs2])
-        multi_f.set_n_jobs(2)
 
         # Test featurize with multiple arguments
         features = multi_f.featurize(0, 2)

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -157,7 +157,7 @@ class TestBaseClass(PymatgenTest):
 
         # Create featurizer
         multi_f = MultipleFeaturizer([self.multiargs, multiargs2])
-        multi_f.set_n_jobs(1)
+        multi_f.set_n_jobs(2)
 
         # Test featurize with multiple arguments
         features = multi_f.featurize(0, 2)

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -8,6 +8,7 @@ from matminer.featurizers.function import FunctionFeaturizer, \
 from matminer.featurizers.base import MultipleFeaturizer
 import numpy as np
 from sympy.parsing.sympy_parser import parse_expr
+from sklearn.exceptions import NotFittedError
 
 
 class TestFunctionFeaturizer(unittest.TestCase):
@@ -70,7 +71,9 @@ class TestFunctionFeaturizer(unittest.TestCase):
         ff = FunctionFeaturizer(latexify_labels=True)
         new_df = ff.featurize_dataframe(self.test_df, 'a', inplace=False)
         self.assertTrue("\sqrt{a}" in new_df.columns)
-
+        # Ensure error is thrown with no labels
+        ff = FunctionFeaturizer(latexify_labels=False)
+        self.assertRaises(NotFittedError, ff.feature_labels)
 
     def test_helper_functions(self):
         test_combo_1 = generate_expressions_combinations(["1 / x", "x ** 2"], 1)

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from matminer.featurizers.function import FunctionFeaturizer, \
     generate_expressions_combinations
+from matminer.featurizers.base import MultipleFeaturizer
 import numpy as np
 from sympy.parsing.sympy_parser import parse_expr
 
@@ -59,6 +60,10 @@ class TestFunctionFeaturizer(unittest.TestCase):
         new_df = ff.featurize_dataframe(self.test_df, 'a', inplace=False)
         self.assertEqual(new_df['sqrt(a)'][0], 1j)
 
+        ff = FunctionFeaturizer(expressions=expressions, multi_feature_depth=2,
+                                combo_function=np.sum)
+        new_df = ff.featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
+        self.assertAlmostEqual(new_df['sqrt(a) + sqrt(b)'][2], 2.41421356)
 
     def test_featurize_labels(self):
         # Test latexification
@@ -81,6 +86,21 @@ class TestFunctionFeaturizer(unittest.TestCase):
                                                          combo_depth=3)
         self.assertTrue(parse_expr("x0 ** 2 / (x1 * x2)") in test_combo_3)
         self.assertEqual(len(test_combo_3), 8)
+
+        test_combo_4 = generate_expressions_combinations(["1 / x", "x ** 2", "exp(x)"],
+                                                         combo_function=np.sum)
+        self.assertEqual(len(test_combo_4), 9)
+        test_combo_4 = generate_expressions_combinations(["1 / x", "x ** 2", "exp(x)"],
+                                                         combo_function=lambda x: x[1]-x[0])
+        self.assertEqual(len(test_combo_4), 18)
+
+    def test_multi_featurizer(self):
+        ff1 = FunctionFeaturizer(expressions=["x ** 2"])
+        ff2 = FunctionFeaturizer(expressions=["exp(x)", "1 / x"])
+        mf = MultipleFeaturizer([ff1, ff2])
+        new_df = mf.featurize_dataframe(self.test_df, ['a', 'b', 'c'],
+                                        inplace=False)
+        self.assertEqual(len(new_df), 11)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A few changes to address #217.

Main change is in the addition of a `generate_feature_labels` method which takes column_ids as input.  Most Featurizers will not use column identity in generating labels, so the default is to return feature_labels, but the addition of this method in the base class allows developers of custom featurizers the ability to customize column names if desired without altering the implicit documentation role of the feature_labels method.

Also added a unittest to ensure FunctionFeaturizer works with MultipleFeaturizer.