### PR TITLE
Function featurize w/ fit

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -135,7 +135,8 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
         return self.featurize_many(X, ignore_errors=True)
 
-    def fit_featurize_dataframe(self, df, col_id, *args, **kwargs):
+    def fit_featurize_dataframe(self, df, col_id, fit_kwargs=None,
+                                *args, **kwargs):
         """
         The dataframe equivalent of fit_transform. Takes a dataframe and
         column id as input, fits the featurizer to that dataframe, and
@@ -151,8 +152,10 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
         Returns:
             updated dataframe based on featurizer fitted to that dataframe.
         """
-        return self.fit(df[col_id]).featurize_dataframe(df, col_id, *args,
-                                                        **kwargs)
+        if fit_kwargs is None:
+            fit_kwargs = {}
+        return self.fit(df[col_id], **fit_kwargs).featurize_dataframe(
+            df, col_id, *args, **kwargs)
 
     def featurize_dataframe(self, df, col_id, ignore_errors=False,
                             return_errors=False, inplace=True):
@@ -361,6 +364,11 @@ class MultipleFeaturizer(BaseFeaturizer):
 
     def feature_labels(self):
         return sum([f.feature_labels() for f in self.featurizers], [])
+
+    def fit(self, X, y=None, **fit_kwargs):
+        for f in self.featurizers:
+            f.fit(X, y, **fit_kwargs)
+        return self
 
     def citations(self):
         return list(set(sum([f.citations() for f in self.featurizers], [])))

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -148,6 +148,9 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
             col_id (str or list of str): column label containing objects to
                 featurize. Can be multiple labels if the featurize function
                 requires multiple inputs.
+            fit_kwargs (dict): params for the fit function in dict form
+            *args: args to featurize_dataframe
+            **kwargs: kwargs to featurize_dataframe
 
         Returns:
             updated dataframe based on featurizer fitted to that dataframe.

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -74,7 +74,6 @@ class FunctionFeaturizer(BaseFeaturizer):
         Returns:
             None
         """
-        col_id = fit_kwargs.get("input_column_names")
         self._input_columns = fit_kwargs.get("input_column_names")
         return self
 
@@ -108,13 +107,14 @@ class FunctionFeaturizer(BaseFeaturizer):
         """
         return list(self._exp_iter(*args, postprocess=self.postprocess))
 
-    def fit_featurize_dataframe(self, df, col_id, *args, **kwargs):
+    def fit_featurize_dataframe(self, df, col_id, fit_kwargs=None, *args, **kwargs):
         """
         Fits and featurizes the dataframe
 
         Args:
             df (DataFrame): Dataframe to use for fitting and to be featurized
             col_id ([str]): columns to be used when fitting
+            fit_kwargs (dict): kwargs to fit in dict form
             *args: *args to featurize_dataframe
             **kwargs: **kwargs to featurize_dataframe
 

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -74,7 +74,8 @@ class FunctionFeaturizer(BaseFeaturizer):
         Returns:
             None
         """
-        self._input_columns = fit_kwargs.get("col_id")
+        col_id = fit_kwargs.get("input_column_names")
+        self._input_columns = fit_kwargs.get("input_column_names")
         return self
 
     @property
@@ -91,43 +92,6 @@ class FunctionFeaturizer(BaseFeaturizer):
             [(n, generate_expressions_combinations(self.expressions, n,
                                                    self.combo_function))
              for n in range(1, self.multi_feature_depth+1)])
-
-    def featurize_dataframe(self, df, col_id, ignore_errors=False,
-                            return_errors=False, inplace=True):
-        """
-        Compute features for all entries contained in input dataframe.
-
-        Args:
-            df (DataFrame): dataframe containing input data
-            col_id (str or list of str): column label containing objects
-                to featurize, can be single or multiple column names
-            ignore_errors (bool): Returns NaN for dataframe rows where
-                exceptions are thrown if True. If False, exceptions
-                are thrown as normal.
-            return_errors (bool). Returns the errors encountered for each
-                row in a separate `XFeaturizer errors` column if True. Requires
-                ignore_errors to be True.
-            inplace (bool): Whether to add new columns to input dataframe (df)
-
-        Returns:
-            updated DataFrame
-
-        """
-        # Generate new dataframe out-of-place
-        new_df = super(FunctionFeaturizer, self).featurize_dataframe(
-            df, col_id, ignore_errors=ignore_errors,
-            return_errors=return_errors, inplace=False)
-
-        # Generate and add new columns names
-        new_col_names = self.generate_string_expressions(col_id)
-        new_df.columns = df.columns.tolist() + new_col_names
-
-        if inplace:
-            for k in new_col_names:
-                df[k] = new_df[k]
-            return df
-        else:
-            return new_df
 
     def featurize(self, *args):
         """
@@ -157,7 +121,7 @@ class FunctionFeaturizer(BaseFeaturizer):
         Returns:
             Featurized dataframe
         """
-        return self.fit(df[col_id], col_id=col_id).featurize_dataframe(
+        return self.fit(df[col_id], input_column_names=col_id).featurize_dataframe(
             df, col_id, *args, **kwargs)
 
     def feature_labels(self):

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -62,7 +62,7 @@ class TestFunctionFeaturizer(unittest.TestCase):
 
         ff = FunctionFeaturizer(expressions=expressions, multi_feature_depth=2,
                                 combo_function=np.sum)
-        new_df = ff.featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
         self.assertAlmostEqual(new_df['sqrt(a) + sqrt(b)'][2], 2.41421356)
 
     def test_featurize_labels(self):
@@ -98,7 +98,10 @@ class TestFunctionFeaturizer(unittest.TestCase):
         ff1 = FunctionFeaturizer(expressions=["x ** 2"])
         ff2 = FunctionFeaturizer(expressions=["exp(x)", "1 / x"])
         mf = MultipleFeaturizer([ff1, ff2])
-        new_df = mf.featurize_dataframe(self.test_df, ['a', 'b', 'c'],
+        col_id = ['a', 'b', 'c']
+        ff1.fit(self.test_df[col_id], col_id=col_id)
+        ff2.fit(self.test_df[col_id], col_id=col_id)
+        new_df = mf.fit_featurize_dataframe(self.test_df, ['a', 'b', 'c'],
                                         inplace=False)
         self.assertEqual(len(new_df), 11)
 

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -99,10 +99,9 @@ class TestFunctionFeaturizer(unittest.TestCase):
         ff2 = FunctionFeaturizer(expressions=["exp(x)", "1 / x"])
         mf = MultipleFeaturizer([ff1, ff2])
         col_id = ['a', 'b', 'c']
-        ff1.fit(self.test_df[col_id], col_id=col_id)
-        ff2.fit(self.test_df[col_id], col_id=col_id)
-        new_df = mf.fit_featurize_dataframe(self.test_df, ['a', 'b', 'c'],
-                                        inplace=False)
+        new_df = mf.fit_featurize_dataframe(
+            self.test_df, col_id, fit_kwargs={"input_column_names": col_id},
+            inplace=False)
         self.assertEqual(len(new_df), 11)
 
 

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from matminer.featurizers.function import FunctionFeaturizer, \
     generate_expressions_combinations
+from matminer.featurizers.base import MultipleFeaturizer
 import numpy as np
 from sympy.parsing.sympy_parser import parse_expr
 
@@ -59,6 +60,10 @@ class TestFunctionFeaturizer(unittest.TestCase):
         new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)
         self.assertEqual(new_df['sqrt(a)'][0], 1j)
 
+        ff = FunctionFeaturizer(expressions=expressions, multi_feature_depth=2,
+                                combo_function=np.sum)
+        new_df = ff.featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
+        self.assertAlmostEqual(new_df['sqrt(a) + sqrt(b)'][2], 2.41421356)
 
     def test_featurize_labels(self):
         # Test latexification
@@ -81,6 +86,21 @@ class TestFunctionFeaturizer(unittest.TestCase):
                                                          combo_depth=3)
         self.assertTrue(parse_expr("x0 ** 2 / (x1 * x2)") in test_combo_3)
         self.assertEqual(len(test_combo_3), 8)
+
+        test_combo_4 = generate_expressions_combinations(["1 / x", "x ** 2", "exp(x)"],
+                                                         combo_function=np.sum)
+        self.assertEqual(len(test_combo_4), 9)
+        test_combo_4 = generate_expressions_combinations(["1 / x", "x ** 2", "exp(x)"],
+                                                         combo_function=lambda x: x[1]-x[0])
+        self.assertEqual(len(test_combo_4), 18)
+
+    def test_multi_featurizer(self):
+        ff1 = FunctionFeaturizer(expressions=["x ** 2"])
+        ff2 = FunctionFeaturizer(expressions=["exp(x)", "1 / x"])
+        mf = MultipleFeaturizer([ff1, ff2])
+        new_df = mf.featurize_dataframe(self.test_df, ['a', 'b', 'c'],
+                                        inplace=False)
+        self.assertEqual(len(new_df), 11)
 
 
 if __name__ == "__main__":

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -19,7 +19,7 @@ class TestFunctionFeaturizer(unittest.TestCase):
     def test_featurize(self):
         ff = FunctionFeaturizer()
         # Test basic default functionality
-        new_df = ff.featurize_dataframe(self.test_df, 'a', inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)
         # ensure NaN for undefined values
         self.assertTrue(pd.isnull(new_df['1/a'][1]))
         self.assertTrue(pd.isnull(new_df['sqrt(a)'][0]))
@@ -32,7 +32,7 @@ class TestFunctionFeaturizer(unittest.TestCase):
         # Test custom expression functionality
         expressions = ["1 / x"]
         ff = FunctionFeaturizer(expressions=expressions)
-        new_df = ff.featurize_dataframe(self.test_df, 'a', inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)
         new_df = new_df.dropna()
         self.assertTrue("1/a" in new_df.columns)
         self.assertFalse("a**2" in new_df.columns)
@@ -41,13 +41,13 @@ class TestFunctionFeaturizer(unittest.TestCase):
 
         # Test multi-functionality
         ff = FunctionFeaturizer(expressions=expressions, multi_feature_depth=2)
-        new_df = ff.featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
         new_df = new_df.dropna()
         self.assertTrue(np.allclose(new_df['1/a'] * new_df['1/b'],
                                     new_df['1/(a*b)']))
 
         ff = FunctionFeaturizer(expressions=expressions, multi_feature_depth=3)
-        new_df = ff.featurize_dataframe(self.test_df, ['a', 'b', 'c'],
+        new_df = ff.fit_featurize_dataframe(self.test_df, ['a', 'b', 'c'],
                                         inplace=False)
         new_df = new_df.dropna()
         self.assertTrue(np.allclose(new_df['1/a']*new_df['1/b']*new_df['1/c'],
@@ -56,14 +56,14 @@ class TestFunctionFeaturizer(unittest.TestCase):
         # Test complex functionality
         expressions = ["sqrt(x)"]
         ff = FunctionFeaturizer(expressions=expressions, postprocess=np.complex)
-        new_df = ff.featurize_dataframe(self.test_df, 'a', inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)
         self.assertEqual(new_df['sqrt(a)'][0], 1j)
 
 
     def test_featurize_labels(self):
         # Test latexification
         ff = FunctionFeaturizer(latexify_labels=True)
-        new_df = ff.featurize_dataframe(self.test_df, 'a', inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)
         self.assertTrue("\sqrt{a}" in new_df.columns)
 
 


### PR DESCRIPTION
Here's a different implementation that addresses #217 using fit.  I think this is less intuitive for the internal code design and the user than what I proposed in #218, and it was definitely more of a pain to develop, but I'll let you all decide which one is preferable.

* `FunctionFeaturizer` has `input_column_names` as an input kwarg, just in case the user knows which columns they want to operate on at the point of construction.
* `FunctionFeaturizer.fit` finds `input_column_names` in its `**kwargs`, which are actually required but not in the signature, and doesn't use either its required argument `X` or optional kwarg `y`.
* `BaseFeaturizer.fit_featurize_dataframe` adds a `fit_kwargs` argument, which is actually a dict, since we're already passing **kwargs to the featurize_dataframe method.
* `FunctionFeaturizer.fit_featurize_dataframe` added.  This fits the column ids and featurizes.  Note that it's hard to imagine users not wanting to fit in this case, so this would be the preferred mode of use for this featurizer, presumably.  This method also can use the input col_ids in both the fitting method (i. e. as input_column_names) and the call to featurize_dataframe.
* `MultipleFeaturizer.fit` added.  This enables, for example, FunctionFeaturizer to be used in MultipleFeaturizer without having to use `FunctionFeaturizer.fit` separately.  Thus `MultipleFeaturizer.fit_featurize_dataframe` (which inherits from `BaseFeaturizer`) works with `FunctionFeaturizer`, but you have to specify the input_column_names and the col_ids separately, e. g. 
```
>>>multifeaturizer.fit_featurize_dataframe(df, ['a', 'b', 'c'], fit_kwargs={'input_column_names': ['a', 'b', 'c'])
```