### PR TITLE
apply shift when calculating bpe + return unchanged vbm/cbm

### DIFF
--- a/matminer/featurizers/bandstructure.py
+++ b/matminer/featurizers/bandstructure.py
@@ -94,7 +94,11 @@ class BranchPointEnergy(BaseFeaturizer):
         return [bpe, vbm-shift, cbm+shift]
 
     def feature_labels(self):
-
+        """
+        Returns ([str]): absolute energy levels as provided in the input
+            BandStructure. "absolute" means no reference energy is subtracted
+            from branch_point_energy, vbm or cbm.
+        """
         return ["branch_point_energy", "vbm_absolute",
                 "cbm_absolute"] if self.calculate_band_edges else [
             "branch_point_energy"]

--- a/matminer/featurizers/tests/test_bandstructure.py
+++ b/matminer/featurizers/tests/test_bandstructure.py
@@ -48,8 +48,8 @@ class BandstructureFeaturesTest(PymatgenTest):
         df_bpe = BranchPointEnergy().featurize_dataframe(self.df,
                                                          col_id=['bs_uniform'])
         self.assertAlmostEqual(df_bpe['branch_point_energy'][0], 5.728, 3)
-        self.assertAlmostEqual(df_bpe['cbm_absolute'][0], 0.497, 3)
-        self.assertAlmostEqual(df_bpe['vbm_absolute'][0], -0.114, 3)
+        self.assertAlmostEqual(df_bpe['cbm_absolute'][0], 6.224, 3)
+        self.assertAlmostEqual(df_bpe['vbm_absolute'][0], 5.614, 3)
 
     def test_BandFeaturizer(self):
         # silicon:


### PR DESCRIPTION
- Previously if target_gap was provided, the branch_point_energy (bpe) calculation wouldn't change.

- Now the unchanged vbm/cbm is returned. The users can subsequently subtract bpe (or vbm/cbm or anything) themselves if they want (i.e. the reference is not decided to be bpe by default).