### PR TITLE
Need a deep-copy for cn_target_motif_op in site.py

### DIFF
--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -204,7 +204,7 @@ class OPSiteFingerprint(BaseFeaturizer):
     def __init__(self, target_motifs=None, dr=0.1, ddr=0.01, ndr=1, dop=0.001,
                  dist_exp=2, zero_ops=True):
         self.cn_target_motif_op = copy.deepcopy(cn_target_motif_op) \
-            if target_motifs is None else target_motifs.copy()
+            if target_motifs is None else copy.deepcopy(target_motifs)
         self.dr = dr
         self.ddr = ddr
         self.ndr = ndr
@@ -430,7 +430,7 @@ class CrystalNNFingerprint(BaseFeaturizer):
             **kwargs: other settings to be passed into CrystalNN class
         """
 
-        self.op_types = op_types.copy()
+        self.op_types = copy.deepcopy(op_types)
         self.cnn = CrystalNN(**kwargs)
 
         self.ops = {}  # load order parameter objects & paramaters
@@ -557,7 +557,7 @@ class CrystalSiteFingerprint(BaseFeaturizer):
                 (bonds with zero charge are also allowed)
         """
 
-        self.optypes = optypes.copy()
+        self.optypes = copy.deepcopy(optypes)
         self.override_cn1 = override_cn1
         self.cutoff_radius = cutoff_radius
         self.tol = tol
@@ -751,11 +751,11 @@ class VoronoiFingerprint(BaseFeaturizer):
         self.cutoff = cutoff
         self.use_weights = use_weights
         self.stats_vol = ['mean', 'std_dev', 'minimum', 'maximum'] \
-            if stats_vol is None else stats_vol.copy()
+            if stats_vol is None else copy.deepcopy(stats_vol)
         self.stats_area = ['mean', 'std_dev', 'minimum', 'maximum'] \
-            if stats_area is None else stats_area.copy()
+            if stats_area is None else copy.deepcopy(stats_area)
         self.stats_dist = ['mean', 'std_dev', 'minimum', 'maximum'] \
-            if stats_dist is None else stats_dist.copy()
+            if stats_dist is None else copy.deepcopy(stats_dist)
 
     @staticmethod
     def vol_tetra(vt1, vt2, vt3, vt4):

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -1,4 +1,5 @@
 from __future__ import division
+import copy
 
 from matminer.utils.data import MagpieData
 
@@ -202,7 +203,7 @@ class OPSiteFingerprint(BaseFeaturizer):
 
     def __init__(self, target_motifs=None, dr=0.1, ddr=0.01, ndr=1, dop=0.001,
                  dist_exp=2, zero_ops=True):
-        self.cn_target_motif_op = cn_target_motif_op.copy() \
+        self.cn_target_motif_op = copy.deepcopy(cn_target_motif_op) \
             if target_motifs is None else target_motifs.copy()
         self.dr = dr
         self.ddr = ddr
@@ -406,7 +407,7 @@ class CrystalNNFingerprint(BaseFeaturizer):
             return CrystalNNFingerprint(op_types, **kwargs)
 
         elif preset == "ops":
-            op_types = cn_target_motif_op.copy()
+            op_types = copy.deepcopy(cn_target_motif_op)
             for k in range(24):
                 if k + 1 in op_types:
                     op_types[k + 1].insert(0, "wt")

--- a/matminer/featurizers/tests/test_site.py
+++ b/matminer/featurizers/tests/test_site.py
@@ -7,7 +7,8 @@ from pymatgen.util.testing import PymatgenTest
 from pymatgen.analysis.local_env import VoronoiNN, JMolNN
 
 from matminer.featurizers.site import AGNIFingerprints, \
-    OPSiteFingerprint, CrystalSiteFingerprint, EwaldSiteEnergy, \
+    OPSiteFingerprint, CrystalNNFingerprint, \
+    CrystalSiteFingerprint, EwaldSiteEnergy, \
     VoronoiFingerprint, ChemEnvSiteFingerprint, \
     CoordinationNumber, ChemicalSRO, GaussianSymmFunc, \
     GeneralizedRadialDistributionFunction, AngularFourierSeries, LocalPropertyDifference
@@ -120,6 +121,11 @@ class FingerprintTests(PymatgenTest):
         ops = opsf.featurize(self.cscl, 0)
         self.assertAlmostEqual(ops[opsf.feature_labels().index(
             'body-centered cubic CN_8')], 0.9555, places=7)
+
+        # The following test aims at ensuring the copying of the OP dictionaries work.
+        opsfp = OPSiteFingerprint()
+        cnnfp = CrystalNNFingerprint.from_preset('ops')
+        self.assertEqual(len([1 for l in opsfp.feature_labels() if l.split()[0] == 'wt']), 0)
 
     def test_crystal_site_fingerprint(self):
         csf = CrystalSiteFingerprint.from_preset('ops')

--- a/matminer/figrecipes/plot.py
+++ b/matminer/figrecipes/plot.py
@@ -517,7 +517,7 @@ class PlotlyFig:
                                'line': {'width': 1,'color': 'black'}
                                } for _ in data]
         if isinstance(markers, dict):
-            markers = [markers.copy() for _ in data]
+            markers = [deepcopy(markers) for _ in data]
 
         if self.colorbar_title == 'auto':
             colorbar_title = pd.Series(colorbar).name
@@ -561,7 +561,7 @@ class PlotlyFig:
                 lines.append(linedict)
 
         if isinstance(lines, dict):
-            lines = [lines.copy() for _ in data]
+            lines = [deepcopy(lines) for _ in data]
 
         for var in [labels, markers, lines]:
             if len(list(var)) != len(data):
@@ -1080,7 +1080,7 @@ class PlotlyFig:
                                colors=colorscale, use_colorscale=use_colorscale,
                                group_stats=group_stats, rugplot=rugplot)
         layout = deepcopy(self.layout)
-        font_style = self.font_style.copy()
+        font_style = deepcopy(self.font_style)
         font_style['size'] = 0.65 * font_style['size']
 
         violin_layout = {k: v for (k, v) in layout.items() if k != 'xaxis'}
@@ -1165,7 +1165,7 @@ class PlotlyFig:
                 values = data[col]
             dimensions.append({'label': col, 'values': values.tolist()})
 
-        font_style = self.font_style.copy()
+        font_style = deepcopy(self.font_style)
         font_style['size'] = 0.7 * font_style['size']
         line = line or {'color': colors,
                         'colorscale': self.colorscale,
@@ -1387,7 +1387,7 @@ class PlotlyFig:
                     count = 0
                     val = 'N/A'
                 x_data.append(val)
-                a_d = annotation_template.copy()
+                a_d = deepcopy(annotation_template)
                 a_d['x'] = x
                 a_d['y'] = y
                 if annotation is None:


### PR DESCRIPTION
There was an undesirable behavior. Consider this snippet:

```
from matminer.featurizers.site import CrystalNNFingerprint, OPSiteFingerprint

cnnfp = CrystalNNFingerprint.from_preset('ops')
opsfp = OPSiteFingerprint()

cnnfp.featurize(s, 0)
opsfp.featurize(s, 0)
```

It returned following error:

```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    opsfp = OPSiteFingerprint()
  File "matminer/matminer/featurizers/site.py", line 224, in __init__
    self.ops[cn].append(LocalStructOrderParams([ot], parameters=[p]))
  File "pymatgen/pymatgen/analysis/local_env.py", line 1397, in __init__
    t + ")!")
ValueError: Unknown order parameter type (wt)!
```

The problem was that we were using shallow copies of the dictionary. I've also tested the 
`dict2 = dict(dict1)`
copying mechanism and the update function.
```
dict2 = dict()
dict2.update(dict1)
```
Neither worked. Only, the deepcopy from the copy module worked.
