### PR TITLE
better labels support in xy plots + debugs and cleanups

### DIFF
--- a/matminer/datasets/dataframe_loader.py
+++ b/matminer/datasets/dataframe_loader.py
@@ -13,11 +13,19 @@ module_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def load_elastic_tensor(include_metadata = False):
-    # ref: Jong, M. De, Chen, W., Angsten, T., Jain, A., Notestine, R., Gamst,
-    # A., Sluiter, M., Ande, C. K., Zwaag, S. Van Der, Plata, J. J., Toher,
-    # C., Curtarolo, S., Ceder, G., Persson, K. a & Asta, M. Charting the
-    # complete elastic properties of inorganic crystalline compounds. Sci.
-    # Data 2, 150009 (2015).
+    """
+    References:
+        Jong, M. De, Chen, W., Angsten, T., Jain, A., Notestine, R., Gamst,
+        A., Sluiter, M., Ande, C. K., Zwaag, S. Van Der, Plata, J. J., Toher,
+        C., Curtarolo, S., Ceder, G., Persson, K. and Asta, M., "Charting the
+        complete elastic properties of inorganic crystalline compounds",
+        Scientific Data volume 2, Article number: 150009 (2015)
+
+    Args:
+        include_metadata (bool): whether to return cif, kpoint_density, poscar
+
+    Returns (pd.DataFrame)
+    """
     df = pandas.read_csv(os.path.join(module_dir, "elastic_tensor.csv"),
         comment="#")
     for i in list(df.index):
@@ -34,10 +42,19 @@ def load_elastic_tensor(include_metadata = False):
         new_columns += ['cif', 'kpoint_density', 'poscar']
     return df[new_columns]
 
+
 def load_piezoelectric_tensor(include_metadata = False):
-    # ref: de Jong, M., Chen, W., Geerlings, H., Asta, M. & Persson, K. A.
-    # A database to enable discovery and design of piezoelectric materials.
-    # Sci. Data 2, 150053 (2015).
+    """
+    References:
+        de Jong, M., Chen, W., Geerlings, H., Asta, M. & Persson, K. A.
+        A database to enable discovery and design of piezoelectric materials.
+        Sci. Data 2, 150053 (2015)
+
+    Args:
+        include_metadata (bool): whether to return cif, meta, poscar
+
+    Returns (pd.DataFrame)
+    """
     df = pandas.read_csv(os.path.join(module_dir, "piezoelectric_tensor.csv"),
         comment="#")
     for i in list(df.index):
@@ -52,11 +69,20 @@ def load_piezoelectric_tensor(include_metadata = False):
         new_columns += ['cif', 'meta', 'poscar']
     return df[new_columns]
 
+
 def load_dielectric_constant(include_metadata = False):
-    # ref: Petousis, I., Mrdjenovich, D., Ballouz, E., Liu, M., Winston, D.,
-    # Chen, W., Graf, T., Schladt, T. D., Persson, K. A. & Prinz, F. B.
-    # High-throughput screening of inorganic compounds for the discovery of
-    # novel dielectric and optical materials. Sci. Data 4, 160134 (2017).
+    """
+    References:
+        Petousis, I., Mrdjenovich, D., Ballouz, E., Liu, M., Winston, D.,
+        Chen, W., Graf, T., Schladt, T. D., Persson, K. A. & Prinz, F. B.
+        High-throughput screening of inorganic compounds for the discovery of
+        novel dielectric and optical materials. Sci. Data 4, 160134 (2017).
+
+    Args:
+        include_metadata (bool): whether to return cif, meta, poscar
+
+    Returns (pd.DataFrame)
+    """
     df = pandas.read_csv(os.path.join(module_dir, "dielectric_constant.csv"),
         comment="#")
     df['cif'] = df['structure']
@@ -70,18 +96,22 @@ def load_dielectric_constant(include_metadata = False):
         new_columns += ['cif', 'meta', 'poscar']
     return df[new_columns]
 
-def load_flla():
-    # ref1: F. Faber, A. Lindmaa, O.A. von Lilienfeld, R. Armiento,
-    # Crystal structure representations for machine learning models
-    # of formation energies, Int. J. Quantum Chem. 115 (2015) 1094–1101.
-    # doi:10.1002/qua.24917.
-    #
-    # The raw data is from:
-    # ref2: Jain, A., Ong, S. P., Hautier, G., Chen, W., Richards, W. D.,
-    # Dacek, S., Cholia, S., Gunter, D., Skinner, D., Ceder, G. & Persson,
-    # K. A. Commentary: The Materials Project: A materials genome approach to
-    # accelerating materials innovation. APL Mater. 1, 11002 (2013).
 
+def load_flla():
+    """
+    References:
+        1) F. Faber, A. Lindmaa, O.A. von Lilienfeld, R. Armiento,
+        "Crystal structure representations for machine learning models of
+        formation energies", Int. J. Quantum Chem. 115 (2015) 1094–1101.
+        doi:10.1002/qua.24917.
+
+        2) (raw data) Jain, A., Ong, S. P., Hautier, G., Chen, W., Richards, W. D.,
+        Dacek, S., Cholia, S., Gunter, D., Skinner, D., Ceder, G. & Persson,
+        K. A. Commentary: The Materials Project: A materials genome approach to
+        accelerating materials innovation. APL Mater. 1, 11002 (2013).
+
+    Returns (pd.DataFrame)
+    """
     df = pandas.read_csv(os.path.join(module_dir, "flla_2015.csv"), comment="#")
     column_headers = ['material_id', 'e_above_hull', 'formula',
                         'nsites', 'structure', 'formation_energy',

--- a/matminer/datasets/dataframe_loader.py
+++ b/matminer/datasets/dataframe_loader.py
@@ -12,7 +12,7 @@ __author__ = "Kyle Bystrom <kylebystrom@berkeley.edu>, " \
 module_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-def load_elastic_tensor(include_metadata = False):
+def load_elastic_tensor(include_metadata=False):
     """
     References:
         Jong, M. De, Chen, W., Angsten, T., Jain, A., Notestine, R., Gamst,
@@ -43,7 +43,7 @@ def load_elastic_tensor(include_metadata = False):
     return df[new_columns]
 
 
-def load_piezoelectric_tensor(include_metadata = False):
+def load_piezoelectric_tensor(include_metadata=False):
     """
     References:
         de Jong, M., Chen, W., Geerlings, H., Asta, M. & Persson, K. A.
@@ -70,7 +70,7 @@ def load_piezoelectric_tensor(include_metadata = False):
     return df[new_columns]
 
 
-def load_dielectric_constant(include_metadata = False):
+def load_dielectric_constant(include_metadata=False):
     """
     References:
         Petousis, I., Mrdjenovich, D., Ballouz, E., Liu, M., Winston, D.,

--- a/matminer/figrecipes/plot.py
+++ b/matminer/figrecipes/plot.py
@@ -469,8 +469,14 @@ class PlotlyFig:
 
         data = []
         for pair in xy_pairs:
+            if len(pair) != 2:
+                raise ValueError('each xy within xy_pairs must have only 2 axes'
+                                 ' : x and y (hence the "pair"); e.g. (x, y)')
             data.append((self._data_from_str(pair[0]),
                          self._data_from_str(pair[1])))
+            if len(list(pair[0])) != len(list(pair[1])):
+                warnings.warn('inequal number of points in x and y: part of the'
+                              ' data not plotted!')
             if isinstance(pair[1], str):
                 names.append(pair[1])
             else:

--- a/matminer/figrecipes/plot.py
+++ b/matminer/figrecipes/plot.py
@@ -393,7 +393,18 @@ class PlotlyFig:
                 either one. Note that if colorcol_range is set, the colorbar
                 ticks will be updated to reflect -min or max+ at the two ends.
             labels (list or [list]): to individually set annotation for scatter
-                point either the same for all traces or can be set for each
+                point either the same for all traces. Note that, several column
+                names can be simultaneously used as labels but it is important
+                to understand that when labels is set, it is assumed that all
+                traces have the same length as the same labels are assigned to
+                all traces.
+                    Examples:
+                        labels = 'formula'
+                        ['material_id', 'formula'] these 2 columns must be available
+                        [['red', 'green', 'blue'], ['warm', 'mild', 'cold']] the
+                        latter example assumes all xy traces have 3 points then
+                        point one has ('red', 'warm') label, 2 has ('green', 'mild')
+                        and finally point 3 ('blue', 'cold')
             limits (dict): The x and y limits defining the ranges the plot will
                 show. Should be in the form {'x': (lower, higher), 'y': (lower,
                 higher)}. Omit either key to prevent limits from being imposed

--- a/matminer/figrecipes/plot.py
+++ b/matminer/figrecipes/plot.py
@@ -392,8 +392,8 @@ class PlotlyFig:
                 if any number is outside of this range, it will be forced to
                 either one. Note that if colorcol_range is set, the colorbar
                 ticks will be updated to reflect -min or max+ at the two ends.
-            labels (list or [list]): to individually set annotation for scatter
-                point either the same for all traces. Note that, several column
+            labels (str or [str] or [list]): to set annotation for scatter
+                points the same for all traces. Note that, several column
                 names can be simultaneously used as labels but it is important
                 to understand that when labels is set, it is assumed that all
                 traces have the same length as the same labels are assigned to
@@ -529,13 +529,13 @@ class PlotlyFig:
 
         if labels is None:
             pass
-        elif not isinstance(labels, (list, np.ndarray, pd.Series)):
+        elif not isinstance(labels, (list, np.ndarray, pd.Series, pd.Index)):
             labels = [self._data_from_str(labels)]
-            if not isinstance(labels[0], (list, np.ndarray, pd.Series)):
-                labels = [[label]*len(data) for label in labels]
-            # labels = [labels] * len(data)
         else:
-            labels = [self._data_from_str(l) for l in labels]
+            if len(list(labels)) == len(data[0][0]) and isinstance(labels[0], str):
+                labels = [labels]
+            else:
+                labels = [self._data_from_str(l) for l in labels]
 
         markers = markers or [{'symbol': 'circle',
                                'line': {'width': 1,'color': 'black'}
@@ -599,8 +599,8 @@ class PlotlyFig:
         if labels is not None:
             for label in labels:
                 if len(list(label)) != len(data[0][0]):
-                    raise ValueError('the length of this label not equal to the'
-                                     'length of the x (or y):\n{}'.format(label))
+                    raise ValueError('the length of this label is not equal to '
+                                     'the length of the x (or y):\n{}'.format(label))
             labels = ['</br>'.join([str(t) for t in l]) for l in zip(*labels)]
 
         for i, xy_pair in enumerate(data):

--- a/matminer/figrecipes/plot.py
+++ b/matminer/figrecipes/plot.py
@@ -438,6 +438,8 @@ class PlotlyFig:
             sizes = [10 * marker_scale] * len(xy_pairs)
         elif isinstance(sizes, str):
             sizes = [self._data_from_str(sizes)] * len(xy_pairs)
+        elif isinstance(sizes, (int, float)):
+            sizes = [sizes]*len(xy_pairs)
         else:
             if len(sizes) != len(xy_pairs):
                 raise ValueError(


### PR DESCRIPTION
## Summary

* labels in xy now takes in one or many inputs (e.g. labels = ['material_id', 'formula']) which is useful when dealing with dataframes. In this example, each scatter point label will show both material_id and formula (previous behavior was trace 1 shows material_id and trace 2 shows formula...)
* int sizes used to throw an error
* a few more checks on data shapes and throwing more informative errors for users if data is not correct
* when loading elastic data, I noticed the docs for load functions are inconsistent so I changed their format w/o modifying content.
* all tests passed and changes are backwards-compatible
* a few updates in xy examples in matminer_examples will follow in a separate PR
