### PR TITLE
Add a multiindex capability

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -396,6 +396,7 @@ class MultipleFeaturizer(BaseFeaturizer):
             warnings.warn(
                 "One or more featurizers overrides featurize_dataframe, "
                 "featurization will be sequential and may diminish performance")
+
         for f in self.featurizers:
             df = f.featurize_dataframe(df, col_id, ignore_errors,
                                        return_errors, inplace, multiindex)
@@ -403,8 +404,8 @@ class MultipleFeaturizer(BaseFeaturizer):
             if multiindex:
                 feature_labels = [(f.__class__.__name__, flabel) for flabel in f.feature_labels()]
             else:
-                feature_labels = f.feature_labels
-                df[feature_labels] = df[feature_labels].applymap(np.squeeze)
+                feature_labels = f.feature_labels()
+            df[feature_labels] = df[feature_labels].applymap(np.squeeze)
         return df
 
     def citations(self):

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -8,6 +8,7 @@ from six import string_types
 from multiprocessing import Pool, cpu_count
 
 from sklearn.base import TransformerMixin, BaseEstimator, is_classifier
+from matminer.utils.conversions import homogenize_multiindex
 
 
 class BaseFeaturizer(BaseEstimator, TransformerMixin):
@@ -155,7 +156,8 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
                                                         **kwargs)
 
     def featurize_dataframe(self, df, col_id, ignore_errors=False,
-                            return_errors=False, inplace=True):
+                            return_errors=False, inplace=True,
+                            multiindex=False):
         """
         Compute features for all entries contained in input dataframe.
 
@@ -194,6 +196,15 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
                                        return_errors=return_errors)
         if return_errors:
             labels.append(self.__class__.__name__ + " Exceptions")
+
+        if multiindex:
+            indices = ([self.__class__.__name__], labels)
+            labels = pd.MultiIndex.from_product(indices)
+            df = homogenize_multiindex(df)
+        elif isinstance(df.columns, pd.MultiIndex):
+            # If input df is multi, but multi not enabled...
+            raise ValueError("Please enable multiindexing to featurize an input"
+                             " dataframe containing a column multiindex.")
 
         # Create dataframe with the new features
         res = pd.DataFrame(features, index=df.index, columns=labels)
@@ -366,7 +377,8 @@ class MultipleFeaturizer(BaseFeaturizer):
         return sum([f.feature_labels() for f in self.featurizers], [])
 
     def featurize_dataframe(self, df, col_id, ignore_errors=False,
-                            return_errors=False, inplace=True):
+                            return_errors=False, inplace=True,
+                            multiindex=False):
         """
         Featurize dataframe is overloaded in order to allow
         compatibility with Featurizers that overload featurize_dataframe

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -376,6 +376,11 @@ class MultipleFeaturizer(BaseFeaturizer):
     def feature_labels(self):
         return sum([f.feature_labels() for f in self.featurizers], [])
 
+    def fit_featurize_dataframe(self, df, col_id, *args, **kwargs):
+        for f in self.featurizers:
+            f.fit(df[col_id])
+        return self.featurize_dataframe(df, col_id, *args, **kwargs)
+
     def featurize_dataframe(self, df, col_id, ignore_errors=False,
                             return_errors=False, inplace=True,
                             multiindex=False):

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -120,7 +120,7 @@ class FunctionFeaturizer(BaseFeaturizer):
         return self
 
     def featurize_dataframe(self, df, col_id, ignore_errors=False,
-                            return_errors=False, inplace=True):
+                            return_errors=False, inplace=True, multiindex=False):
         """
         Custom featurize dataframe method that sets the column labels
         using the fit method and then featurizes the dataframe similarly

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -272,6 +272,93 @@ class TestBaseClass(PymatgenTest):
         f.class_names = ['A', 'B', 'C']
         self.assertEquals(['ML P(A)', 'ML P(B)'], f.feature_labels())
 
+    def test_multiindex_inplace(self):
+        df_1lvl = pd.DataFrame({'x': [1, 2, 3]})
+        df_2lvl = pd.DataFrame({'x': [1, 2, 3]})
+        df_2lvl.columns = pd.MultiIndex.from_product((["Custom"],
+                                                      df_2lvl.columns.values))
+        df_3lvl = pd.DataFrame({'x': [1, 2, 3]})
+        df_3lvl.columns = pd.MultiIndex.from_product((["Custom"],
+                                                      ["Custom2"],
+                                                      df_3lvl.columns.values))
+
+        # If input dataframe has flat column index
+        self.multi.featurize_dataframe(df_1lvl, 'x', multiindex=True)
+        self.assertEqual(df_1lvl[("Input Data", "x")].iloc[0], 1)
+        self.assertEqual(df_1lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
+
+        # If input dataframe has 2-lvl column index
+        self.multi.featurize_dataframe(df_2lvl, ("Custom", 'x'), multiindex=True)
+        self.assertEqual(df_2lvl[("Custom", "x")].iloc[0], 1)
+        self.assertEqual(df_2lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
+
+        # If input dataframe has 2+ lvl column index
+        with self.assertRaises(IndexError):
+            self.multi.featurize_dataframe(df_3lvl, ("Custom", "Custom2", 'x'), multiindex=True)
+
+        # Make sure error is thrown when input df  is multiindexed, but multiindex not enabled
+        df_compoundkey = pd.DataFrame({'x': [1, 2, 3]})
+        df_compoundkey.columns = pd.MultiIndex.from_product((["CK"],
+                                                             df_compoundkey.columns.values))
+        with self.assertRaises(ValueError):
+            self.multi.featurize_dataframe(df_compoundkey, ("CK", "x"))
+
+    def test_multiindex_return(self):
+
+        # For inplace=False, where the method of assigning keys is different
+        df_1lvl = pd.DataFrame({'x': [1, 2, 3]})
+        df_2lvl = pd.DataFrame({'x': [1, 2, 3]})
+        df_2lvl.columns = pd.MultiIndex.from_product((["Custom"],
+                                                      df_2lvl.columns.values))
+        df_3lvl = pd.DataFrame({'x': [1, 2, 3]})
+        df_3lvl.columns = pd.MultiIndex.from_product((["Custom"],
+                                                      ["Custom2"],
+                                                      df_3lvl.columns.values))
+        # If input dataframe has flat column index
+        df_1lvl = self.multi.featurize_dataframe(df_1lvl, 'x', inplace=False, multiindex=True)
+        self.assertEqual(df_1lvl[("Input Data", "x")].iloc[0], 1)
+        self.assertEqual(df_1lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
+
+        # If input dataframe has 2-lvl column index
+        df_2lvl = self.multi.featurize_dataframe(df_2lvl, ("Custom", 'x'), inplace=False, multiindex=True)
+        self.assertEqual(df_2lvl[("Custom", "x")].iloc[0], 1)
+        self.assertEqual(df_2lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
+
+        # If input dataframe has 2+ lvl column index
+        with self.assertRaises(IndexError):
+            _ = self.multi.featurize_dataframe(df_3lvl, ("Custom", "Custom2", 'x'), inplace=False, multiindex=True)
+
+    def test_multiindex_in_multifeaturizer(self):
+        # Make sure multiplefeaturizer returns the correct sub-featurizer multiindex keys
+        mf = MultipleFeaturizer([self.multi, self.single])
+
+        df_1lvl = pd.DataFrame({'x': [1, 2, 3]})
+        df_2lvl = pd.DataFrame({'x': [1, 2, 3]})
+        df_2lvl.columns = pd.MultiIndex.from_product((["Custom"],
+                                                      df_2lvl.columns.values))
+        df_3lvl = pd.DataFrame({'x': [1, 2, 3]})
+        df_3lvl.columns = pd.MultiIndex.from_product((["Custom"],
+                                                      ["Custom2"],
+                                                      df_3lvl.columns.values))
+
+        # If input dataframe has flat column index
+        mf.featurize_dataframe(df_1lvl, 'x', multiindex=True)
+        self.assertEqual(df_1lvl[("Input Data", "x")].iloc[0], 1)
+        self.assertEqual(df_1lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
+        self.assertEqual(df_1lvl[("SingleFeaturizer", "y")].iloc[0], 2)
+
+
+        # If input dataframe has 2-lvl column index
+        mf.featurize_dataframe(df_2lvl, ("Custom", 'x'), multiindex=True)
+        self.assertEqual(df_2lvl[("Custom", "x")].iloc[0], 1)
+        self.assertEqual(df_2lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
+        self.assertEqual(df_2lvl[("SingleFeaturizer", "y")].iloc[0], 2)
+
+
+        # If input dataframe has 2+ lvl column index
+        with self.assertRaises(IndexError):
+            _ = self.multi.featurize_dataframe(df_3lvl, ("Custom", "Custom2", 'x'), multiindex=True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -8,7 +8,8 @@ import warnings
 from pymatgen.util.testing import PymatgenTest
 from sklearn.dummy import DummyRegressor, DummyClassifier
 
-from matminer.featurizers.base import BaseFeaturizer, MultipleFeaturizer, StackedFeaturizer
+from matminer.featurizers.base import BaseFeaturizer, MultipleFeaturizer, \
+    StackedFeaturizer
 from matminer.featurizers.function import FunctionFeaturizer
 
 
@@ -70,11 +71,13 @@ class MultiArgs2(SingleFeaturizerMultiArgs):
     def feature_labels(self):
         return ['y2']
 
+
 class FittableFeaturizer(BaseFeaturizer):
     """
     This test featurizer tests fitting qualities of BaseFeaturizer, including
     refittability and different results based on different fits.
     """
+
     def fit(self, X, y=None, **fit_kwargs):
         self._features = ['a', 'b', 'c'][:len(X)]
         return self
@@ -183,7 +186,6 @@ class TestBaseClass(PymatgenTest):
         self.assertArrayAlmostEqual([[5, 5], [7, 7], [9, 9]], data[['y', 'y2']])
 
     def test_featurize_many(self):
-
         # Single argument
         s = self.single
         s.set_n_jobs(2)
@@ -197,7 +199,6 @@ class TestBaseClass(PymatgenTest):
         self.assertArrayAlmostEqual(mat, [[5], [7], [9]])
 
     def test_multiprocessing_df(self):
-
         # Single argument
         s = self.single
         data = self.make_test_data()
@@ -257,7 +258,7 @@ class TestBaseClass(PymatgenTest):
 
         #  Test the prediction
         f.model = model
-        self.assertEquals([2./3], f.featurize(data['x'][0]))
+        self.assertEquals([2. / 3], f.featurize(data['x'][0]))
 
         #  Test the feature labels
         self.assertRaises(ValueError, f.feature_labels)
@@ -268,7 +269,7 @@ class TestBaseClass(PymatgenTest):
         data['y'] = [0, 2, 1]
         model.fit(self.multi.featurize_many(data['x']), data['y'])
 
-        self.assertArrayAlmostEqual([1./3]*2, f.featurize(data['x'][0]))
+        self.assertArrayAlmostEqual([1. / 3] * 2, f.featurize(data['x'][0]))
         f.class_names = ['A', 'B', 'C']
         self.assertEquals(['ML P(A)', 'ML P(B)'], f.feature_labels())
 
@@ -288,13 +289,15 @@ class TestBaseClass(PymatgenTest):
         self.assertEqual(df_1lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
 
         # If input dataframe has 2-lvl column index
-        self.multi.featurize_dataframe(df_2lvl, ("Custom", 'x'), multiindex=True)
+        self.multi.featurize_dataframe(df_2lvl, ("Custom", 'x'),
+                                       multiindex=True)
         self.assertEqual(df_2lvl[("Custom", "x")].iloc[0], 1)
         self.assertEqual(df_2lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
 
         # If input dataframe has 2+ lvl column index
         with self.assertRaises(IndexError):
-            self.multi.featurize_dataframe(df_3lvl, ("Custom", "Custom2", 'x'), multiindex=True)
+            self.multi.featurize_dataframe(df_3lvl, ("Custom", "Custom2", 'x'),
+                                           multiindex=True)
 
         # Make sure error is thrown when input df  is multiindexed, but multiindex not enabled
         df_compoundkey = pd.DataFrame({'x': [1, 2, 3]})
@@ -304,7 +307,6 @@ class TestBaseClass(PymatgenTest):
             self.multi.featurize_dataframe(df_compoundkey, ("CK", "x"))
 
     def test_multiindex_return(self):
-
         # For inplace=False, where the method of assigning keys is different
         df_1lvl = pd.DataFrame({'x': [1, 2, 3]})
         df_2lvl = pd.DataFrame({'x': [1, 2, 3]})
@@ -315,18 +317,22 @@ class TestBaseClass(PymatgenTest):
                                                       ["Custom2"],
                                                       df_3lvl.columns.values))
         # If input dataframe has flat column index
-        df_1lvl = self.multi.featurize_dataframe(df_1lvl, 'x', inplace=False, multiindex=True)
+        df_1lvl = self.multi.featurize_dataframe(df_1lvl, 'x', inplace=False,
+                                                 multiindex=True)
         self.assertEqual(df_1lvl[("Input Data", "x")].iloc[0], 1)
         self.assertEqual(df_1lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
 
         # If input dataframe has 2-lvl column index
-        df_2lvl = self.multi.featurize_dataframe(df_2lvl, ("Custom", 'x'), inplace=False, multiindex=True)
+        df_2lvl = self.multi.featurize_dataframe(df_2lvl, ("Custom", 'x'),
+                                                 inplace=False, multiindex=True)
         self.assertEqual(df_2lvl[("Custom", "x")].iloc[0], 1)
         self.assertEqual(df_2lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
 
         # If input dataframe has 2+ lvl column index
         with self.assertRaises(IndexError):
-            _ = self.multi.featurize_dataframe(df_3lvl, ("Custom", "Custom2", 'x'), inplace=False, multiindex=True)
+            _ = self.multi.featurize_dataframe(df_3lvl,
+                                               ("Custom", "Custom2", 'x'),
+                                               inplace=False, multiindex=True)
 
     def test_multiindex_in_multifeaturizer(self):
         # Make sure multiplefeaturizer returns the correct sub-featurizer multiindex keys
@@ -347,17 +353,17 @@ class TestBaseClass(PymatgenTest):
         self.assertEqual(df_1lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
         self.assertEqual(df_1lvl[("SingleFeaturizer", "y")].iloc[0], 2)
 
-
         # If input dataframe has 2-lvl column index
         mf.featurize_dataframe(df_2lvl, ("Custom", 'x'), multiindex=True)
         self.assertEqual(df_2lvl[("Custom", "x")].iloc[0], 1)
         self.assertEqual(df_2lvl[("MultipleFeatureFeaturizer", "w")].iloc[0], 0)
         self.assertEqual(df_2lvl[("SingleFeaturizer", "y")].iloc[0], 2)
 
-
         # If input dataframe has 2+ lvl column index
         with self.assertRaises(IndexError):
-            _ = self.multi.featurize_dataframe(df_3lvl, ("Custom", "Custom2", 'x'), multiindex=True)
+            _ = self.multi.featurize_dataframe(df_3lvl,
+                                               ("Custom", "Custom2", 'x'),
+                                               multiindex=True)
 
 
 if __name__ == '__main__':

--- a/matminer/utils/conversions.py
+++ b/matminer/utils/conversions.py
@@ -6,30 +6,32 @@ from pymatgen import Composition
 from pymatgen.core.structure import IStructure
 
 
-def homogenize_multiindex(df, coerce=False):
+def homogenize_multiindex(df, default_key, coerce=False):
     """
-    Homogenizes a dataframe column index to a 2-layer multiindex.
+    Homogenizes a dataframe column index to a 2-level multiindex.
 
     Args:
         df (pandas DataFrame): A dataframe
-        coerce (bool): If True, try to force a 2+ level multiindex to a 2-layer
+        default_key (str): The key to use when a single Index must be converted
+            to a 2-level index. This key is then used as a parent of all
+            keys present in the original 1-level index.
+        coerce (bool): If True, try to force a 2+ level multiindex to a 2-level
             multiindex.
 
     Returns:
         df (pandas DataFrame): A dataframe with a 2-layer multiindex.
     """
-    nlevels = df.columns.nlevels
     if not isinstance(df.columns, pd.MultiIndex):
-        cols = pd.MultiIndex.from_product((["Input Data"], df.columns.values))
+        cols = pd.MultiIndex.from_product(([default_key], df.columns.values))
         df.columns = cols
         return df
-    elif nlevels == 2:
+    elif df.columns.nlevels == 2:
         return df
     elif coerce:
         # Drop levels lower than the base column indices
         warnings.warn("Multiindex has nlevels more than 2! Coercing...")
-        l1 = df.columns.get_level_values(nlevels - 1)
-        l2 = df.columns.get_level_values(nlevels - 2)
+        l1 = df.columns.get_level_values(df.columns.nlevels - 1)
+        l2 = df.columns.get_level_values(df.columns.nlevels - 2)
         cols = pd.MultiIndex.from_arrays((l2, l1))
         df.columns = cols
         return df

--- a/matminer/utils/conversions.py
+++ b/matminer/utils/conversions.py
@@ -1,11 +1,42 @@
 import json
-
+import warnings
 from monty.json import MontyDecoder
-from pandas import Series
-
+import pandas as pd
 from pymatgen import Composition
 from pymatgen.core.structure import IStructure
 
+
+def homogenize_multiindex(df, coerce=False):
+    """
+    Homogenizes a dataframe column index to a 2-layer multiindex.
+
+    Args:
+        df (pandas DataFrame): A dataframe
+        coerce (bool): If True, try to force a 2+ level multiindex to a 2-layer
+            multiindex.
+
+    Returns:
+        df (pandas DataFrame): A dataframe with a 2-layer multiindex.
+    """
+    nlevels = df.columns.nlevels
+    if not isinstance(df.columns, pd.MultiIndex):
+        cols = pd.MultiIndex.from_product((["Input Data"], df.columns.values))
+        df.columns = cols
+        return df
+    elif nlevels == 2:
+        return df
+    elif coerce:
+        # Drop levels lower than the base column indices
+        warnings.warn("Multiindex has nlevels more than 2! Coercing...")
+        l1 = df.columns.get_level_values(nlevels - 1)
+        l2 = df.columns.get_level_values(nlevels - 2)
+        cols = pd.MultiIndex.from_arrays((l2, l1))
+        df.columns = cols
+        return df
+    else:
+        raise IndexError("An input dataframe of 2+ levels cannot be used for"
+                         "multiindexed Matminer featurization without coercion "
+                         "to 2 levels.")
 
 def str_to_composition(series, reduce=False):
     """
@@ -98,8 +129,8 @@ def structure_to_oxidstructure(series, inplace=False, **kwargs):
     if inplace:
         series.map(lambda s: s.add_oxidation_state_by_guess(**kwargs))
     else:
-        copy = Series(data=[x.copy() for x in series.tolist()],
-                      index=series.index, dtype=series.dtype)
+        copy = pd.Series(data=[x.copy() for x in series.tolist()],
+                         index=series.index, dtype=series.dtype)
         copy.map(lambda s: s.add_oxidation_state_by_guess(**kwargs))
         return copy
 
@@ -115,5 +146,5 @@ def composition_to_oxidcomposition(series, **kwargs):
     Returns:
         a pd.Series with oxidation state Composition object components
     """
-    
+
     return series.map(lambda c: c.add_charges_from_oxi_state_guesses(**kwargs))


### PR DESCRIPTION
## Summary
Closes #113 
Closes #236

* multiindex is an arg to featurize_dataframe in BaseFeaturizer
* Resulting dataframe has a 2-level multiindex; top level is the featurizer class name (e.g., ElementProperty), bottom level is the feature (e.g., mean X)
* Works w/ inplace options, 2-level multiindex input df, and regular input df
* Works w/ MultipleFeaturizer (puts classnames of constituent featurizers in the df, see example)
* Also, added fit_featurize_dataframe for MultipleFeaturizer

Example:
```python
import pandas as pd
from pymatgen import Structure
from matminer.data_retrieval.retrieve_MP import MPDataRetrieval
from matminer.featurizers.structure import BondFractions, BagofBonds
from matminer.featurizers.base import MultipleFeaturizer

df_mp = MPDataRetrieval().get_dataframe(criteria={'pretty_formula': 'Si2N2O'}, properties=['structure', 'unit_cell_formula']).head(n=3)
df_mp['structure'] = [Structure.from_dict(i) for i in df_mp['structure']]
bf = BondFractions()
bob = BagofBonds()
mf = MultipleFeaturizer([bf, bob])
mf.fit_featurize_dataframe(df_mp, "structure", multiindex=True)
print(df_mp)
```

Shows:
```
                                                    Input Data                                       BondFractions                                                                        \
                                                     structure                  unit_cell_formula N - N bond frac. N - O bond frac. N - Si bond frac. O - O bond frac. O - Si bond frac.   
material_id                                                                                                                                                                                
mp-4497      [[1.88520218 0.44903263 3.23761984] N, [ 4.332...    {'Si': 4.0, 'O': 2.0, 'N': 4.0}              0.0              0.0          0.750000              0.0          0.250000   
mp-4644      [[1.1942206  4.00780162 4.90440004] N, [ 1.120...  {'Si': 16.0, 'O': 8.0, 'N': 16.0}              0.0              0.0          0.727273              0.0          0.272727   
mp-4400      [[0.6663568  1.21773876 9.62247197] N, [3.0881...  {'Si': 12.0, 'O': 6.0, 'N': 12.0}              0.0              0.0          0.666667              0.0          0.333333   

                               BagofBonds                                                                                                                                                       \
            Si - Si bond frac.  O site #0  O site #1  O site #2  O site #3  O site #4  O site #5  O site #6  O site #7  Si site #0  Si site #1  Si site #2  Si site #3  Si site #4  Si site #5   
material_id                                                                                                                                                                                      
mp-4497                    0.0  73.516695  73.516695   0.000000   0.000000   0.000000   0.000000   0.000000   0.000000  281.628946  281.628946  281.628946  281.628946    0.000000    0.000000   
mp-4644                    0.0  73.516695  73.516695  73.516695  73.516695  73.516695  73.516695  73.516695  73.516695  281.628946  281.628946  281.628946  281.628946  281.628946  281.628946   
mp-4400                    0.0  73.516695  73.516695  73.516695  73.516695  73.516695  73.516695   0.000000   0.000000  281.628946  281.628946  281.628946  281.628946  281.628946  281.628946 


... 
```
