### PR TITLE
minor bugfix: set accuracy to int, None is not accepted.

### DIFF
--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -1073,7 +1073,7 @@ class EwaldEnergy(BaseFeaturizer):
     Features:
         ewald_energy - Coulomb interaction energy of the structure"""
 
-    def __init__(self, accuracy=12):
+    def __init__(self, accuracy=4):
         """
         Args:
             accuracy (int): Accuracy of Ewald summation, number of decimal places

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -1073,7 +1073,7 @@ class EwaldEnergy(BaseFeaturizer):
     Features:
         ewald_energy - Coulomb interaction energy of the structure"""
 
-    def __init__(self, accuracy=None):
+    def __init__(self, accuracy=12):
         """
         Args:
             accuracy (int): Accuracy of Ewald summation, number of decimal places


### PR DESCRIPTION
I set it to 12 that is the default for acc_factor in pymatgen's EwaldSummation.