### PR TITLE
small change in PartialRadialDistributionFunction

### DIFF
--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -282,7 +282,7 @@ class PartialRadialDistributionFunction(BaseFeaturizer):
         elements = set([Element(e) for e in self.include_elems])
 
         # Get all of elements that appaer
-        for strc, in X:
+        for strc in X:
             elements.update([e.element if isinstance(e, Specie) else e for e in strc.composition.keys()])
 
         # Remove the elements excluded by the user

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -164,15 +164,15 @@ class StructureFeaturesTest(PymatgenTest):
 
         # Check the fit operation
         featurizer = PartialRadialDistributionFunction()
-        featurizer.fit(zip([self.diamond, self.cscl, self.ni3al]))
+        featurizer.fit([self.diamond, self.cscl, self.ni3al])
         self.assertEqual({'Cs', 'Cl', 'C', 'Ni', 'Al'}, set(featurizer.elements_))
 
         featurizer.exclude_elems = ['Cs', 'Al']
-        featurizer.fit(zip([self.diamond, self.cscl, self.ni3al]))
+        featurizer.fit([self.diamond, self.cscl, self.ni3al])
         self.assertEqual({'Cl', 'C', 'Ni'}, set(featurizer.elements_))
 
         featurizer.include_elems = ['H']
-        featurizer.fit(zip([self.diamond, self.cscl, self.ni3al]))
+        featurizer.fit([self.diamond, self.cscl, self.ni3al])
         self.assertEqual({'H', 'Cl', 'C', 'Ni'}, set(featurizer.elements_))
 
         # Check the feature labels


### PR DESCRIPTION
## Summary

"for strc, in X:" to "for strc in X:" to make this featurizer consistent with BondFractions and BagofBonds that just take a list of Structures.

@WardLT , is it necessary to assume X a list of tuples here?