### PR TITLE
featurize_dataframe debug in PartialRadialDistributionFunction

### DIFF
--- a/matminer/featurizers/bandstructure.py
+++ b/matminer/featurizers/bandstructure.py
@@ -9,7 +9,6 @@ from matminer.featurizers.base import BaseFeaturizer
 from pymatgen import Spin
 from pymatgen.electronic_structure.bandstructure import BandStructure, \
     BandStructureSymmLine
-from pymatgen.electronic_structure.dos import CompleteDos
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 __author__ = 'Anubhav Jain <ajain@lbl.gov>'

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -370,7 +370,7 @@ class PartialRadialDistributionFunction(BaseFeaturizer):
 
             prdf[key] = rdf
 
-        return dist_bins, prdf
+        return dist_bins[:-1], prdf
 
     def _make_bins(self):
         """Generate the edges of the bins for the PRDF

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -143,13 +143,13 @@ class StructureFeaturesTest(PymatgenTest):
         self.assertEqual(len(prdf.values()), 1)
         self.assertAlmostEqual(prdf[('C', 'C')][int(round(1.4 / 0.1))], 0)
         self.assertAlmostEqual(prdf[('C', 'C')][int(round(1.5 / 0.1))], 1.32445167622)
-        self.assertAlmostEqual(max(distances), 20.0)
+        self.assertAlmostEqual(max(distances), 19.9)
         self.assertAlmostEqual(prdf[('C', 'C')][int(round(19.9 / 0.1))], 0.07197902)
 
         # Test a few peaks in CsCl, make sure it gets all types correctly
         distances, prdf = PartialRadialDistributionFunction(cutoff=10).compute_prdf(self.cscl)
         self.assertEqual(len(prdf.values()), 4)
-        self.assertAlmostEqual(max(distances), 10.0)
+        self.assertAlmostEqual(max(distances), 9.9)
         self.assertAlmostEqual(prdf[('Cs', 'Cl')][int(round(3.6 / 0.1))], 0.477823197)
         self.assertAlmostEqual(prdf[('Cl', 'Cs')][int(round(3.6 / 0.1))], 0.477823197)
         self.assertAlmostEqual(prdf[('Cs', 'Cs')][int(round(3.6 / 0.1))], 0)

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -191,6 +191,12 @@ class StructureFeaturesTest(PymatgenTest):
         prdf = featurizer.compute_prdf(self.diamond)[1]
         self.assertArrayAlmostEqual(features, prdf[('C', 'C')])
 
+        # Check the featurize_dataframe
+        df = pd.DataFrame.from_dict({"structure": [self.diamond, self.cscl]})
+        featurizer.fit(df["structure"])
+        df = featurizer.featurize_dataframe(df, col_id="structure")
+
+
         # Make sure labels and features are in the same order
         featurizer.elements_ = ['Al', 'Ni']
         features = featurizer.featurize(self.ni3al)

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -195,7 +195,9 @@ class StructureFeaturesTest(PymatgenTest):
         df = pd.DataFrame.from_dict({"structure": [self.diamond, self.cscl]})
         featurizer.fit(df["structure"])
         df = featurizer.featurize_dataframe(df, col_id="structure")
-
+        self.assertEqual(df["Cs-Cl PRDF r=0.00-0.10"][0], 0.0)
+        self.assertAlmostEqual(df["Cl-Cl PRDF r=19.70-19.80"][1], 0.049, 3)
+        self.assertEqual(df["Cl-Cl PRDF r=19.90-20.00"][0], 0.0)
 
         # Make sure labels and features are in the same order
         featurizer.elements_ = ['Al', 'Ni']


### PR DESCRIPTION
## Summary

PartialRadialDistributionFunction featurize method works fine. However, when featurize_dataframe is called, "zeros" will be used which has unequal length to prdf. This was very confusing so I added featurize_dataframe test for this featurizer as well.

dist_bins modified to be the start of each bin as is supposed to be based on the docs. 

@WardLT , could you please check to see the way I resolve this issue is correct?