### PR TITLE
add *.tsv file to package files (to be included in pip install)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE *.txt
 include matminer/datasets/*.csv
 include matminer/featurizers/*.yaml
 include matminer/utils/data_files/*.csv
+include matminer/utils/data_files/*.tsv
 include matminer/utils/data_files/*.json
 include matminer/utils/data_files/magpie_elementdata/*.table
 recursive-include matminer *

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         packages=find_packages(),
         package_data={'matminer.datasets': ['*.csv'],
                       'matminer.featurizers': ["*.yaml"],
-                      'matminer.utils.data_files': ['*.csv', '*.json', 'magpie_elementdata/*.table']},
+                      'matminer.utils.data_files': ['*.csv', '*.tsv', '*.json', 'magpie_elementdata/*.table']},
         zip_safe=False,
         install_requires=['pymatgen>=2018.4.20', 'tqdm>=4.14.0', 'pandas>=0.20.1',
                           'pymongo>=3.4.0', 'pint>=0.8.1', 'six>=1.10.0',


### PR DESCRIPTION
## Summary

matminer/utils/data_files/MiedemaLiquidDeltaHf.tsv (needed by YangSolidSolution) is missing when matminer was installed as a dependency of another package. I tested locally and pip install matminer results in this file missing. Possible solutions:
1) add *.tsv (tab-separated) files to package data (current PR)
2) change that one file to .csv