### PR TITLE
Improvements to basefeaturizer (+pbar)

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -480,8 +480,7 @@ class StackedFeaturizer(BaseFeaturizer):
 
         # Present warning about class_names
         if self.class_names is None and self._is_classifier():
-            print('WARNING: Class names are required for featurize_dataframe and feature_labels',
-                  file=sys.stderr)
+            warnings.warn('Class names are required for featurize_dataframe and feature_labels')
 
     def _is_classifier(self):
         """Whether the underlying model is a classifier

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -404,24 +404,17 @@ class MultipleFeaturizer(BaseFeaturizer):
             f.fit(df[col_id])
         return self.featurize_dataframe(df, col_id, *args, **kwargs)
 
-    def featurize_dataframe(self, df, col_id, ignore_errors=False,
-                            return_errors=False, inplace=True,
-                            multiindex=False, pbar=False):
+    def featurize_dataframe(self, df, col_id, **kwargs):
         """
         Featurize dataframe is overloaded in order to allow
         compatibility with Featurizers that overload featurize_dataframe
         """
+        multiindex = kwargs.get('multiindex', False)
 
         if multiindex:
             if not isinstance(df.columns, pd.MultiIndex):
                 col_id = ("Input Data", col_id)
             df = homogenize_multiindex(df, "Input Data")
-
-            # todo: Make pbar work with multiindexing
-            if pbar:
-                warnings.warn("Use of the progress bar with multiindexing "
-                              "is not yet supported. Setting pbar=False...")
-                pbar = False
 
         # Detect if any featurizers override featurize_dataframe
         override = ["featurize_dataframe" in f.__class__.__dict__.keys()
@@ -432,10 +425,7 @@ class MultipleFeaturizer(BaseFeaturizer):
                 "featurization will be sequential and may diminish performance")
 
         for f in self.featurizers:
-            df = f.featurize_dataframe(df, col_id, ignore_errors=ignore_errors,
-                                       return_errors=return_errors,
-                                       inplace=inplace, multiindex=multiindex,
-                                       pbar=pbar)
+            df = f.featurize_dataframe(df, col_id, **kwargs)
 
             if multiindex:
                 feature_labels = [(f.__class__.__name__, flabel) for flabel

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -405,14 +405,16 @@ class MultipleFeaturizer(BaseFeaturizer):
         return sum([f.feature_labels() for f in self.featurizers], [])
 
     def fit_featurize_dataframe(self, df, col_id, *args, **kwargs):
+        """
+        Accepts the same arguments as BaseFeaturizer.fit_featurize_dataframe.
+        """
         for f in self.featurizers:
             f.fit(df[col_id])
         return self.featurize_dataframe(df, col_id, *args, **kwargs)
 
     def featurize_dataframe(self, df, col_id, *args, **kwargs):
         """
-        Featurize dataframe is overloaded in order to allow
-        compatibility with Featurizers that overload featurize_dataframe
+        Accepts the same arguments as BaseFeaturizer.featurize_dataframe.
         """
         multiindex = kwargs.get('multiindex', False)
 
@@ -420,14 +422,6 @@ class MultipleFeaturizer(BaseFeaturizer):
             if not isinstance(df.columns, pd.MultiIndex):
                 col_id = ("Input Data", col_id)
             df = homogenize_multiindex(df, "Input Data")
-
-        # Detect if any featurizers override featurize_dataframe
-        override = ["featurize_dataframe" in f.__class__.__dict__.keys()
-                    for f in self.featurizers]
-        if any(override):
-            warnings.warn(
-                "One or more featurizers overrides featurize_dataframe, "
-                "featurization will be sequential and may diminish performance")
 
         for f in self.featurizers:
             df = f.featurize_dataframe(df, col_id, *args, **kwargs)

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -22,6 +22,9 @@ class FunctionFeaturizer(BaseFeaturizer):
     """
     Features from functions applied to existing features, e.g. "1/x"
 
+    This featurizer must be fit either by calling .fit_featurize_dataframe
+    or by calling .fit followed by featurize_dataframe.
+
     This class featurizes a dataframe according to a set
     of expressions representing functions to apply to
     existing features. The approach here has uses a sympy-based
@@ -118,34 +121,6 @@ class FunctionFeaturizer(BaseFeaturizer):
         elif isinstance(X, Series):
             self._feature_labels = self.generate_string_expressions(X.name)
         return self
-
-    def featurize_dataframe(self, df, col_id, *args, **kwargs):
-        """
-        Custom featurize dataframe method that sets the column labels
-        using the fit method and then featurizes the dataframe similarly
-        as the base class
-
-        Args:
-            df (pandas.DataFrame): Dataframe containing input data.
-            col_id (str or list of str): column label containing objects to
-                featurize.
-            ignore_errors (bool): Returns NaN for dataframe rows where
-                exceptions are thrown if True. If False, exceptions
-                are thrown as normal.
-            return_errors (bool). Returns the errors encountered for each
-                row in a separate `XFeaturizer errors` column if True. Requires
-                ignore_errors to be True.
-            inplace (bool): Whether to add new columns to input dataframe (df)
-            multiindex (bool):  Use a 2-level pandas index for columns in the
-                returned dataframe.
-            pbar (bool): Whether to use a progress bar for each featurizer.
-
-        Returns:
-            updated DataFrame.
-        """
-        self.fit(df[col_id])
-        return super(FunctionFeaturizer, self).featurize_dataframe(
-            df, col_id, *args, **kwargs)
 
     def generate_string_expressions(self, input_variable_names):
         """

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -119,9 +119,7 @@ class FunctionFeaturizer(BaseFeaturizer):
             self._feature_labels = self.generate_string_expressions(X.name)
         return self
 
-    def featurize_dataframe(self, df, col_id, ignore_errors=False,
-                            return_errors=False, inplace=True, multiindex=False,
-                            pbar=False):
+    def featurize_dataframe(self, df, col_id, *args, **kwargs):
         """
         Custom featurize dataframe method that sets the column labels
         using the fit method and then featurizes the dataframe similarly
@@ -138,13 +136,16 @@ class FunctionFeaturizer(BaseFeaturizer):
                 row in a separate `XFeaturizer errors` column if True. Requires
                 ignore_errors to be True.
             inplace (bool): Whether to add new columns to input dataframe (df)
+            multiindex (bool):  Use a 2-level pandas index for columns in the
+                returned dataframe.
+            pbar (bool): Whether to use a progress bar for each featurizer.
 
         Returns:
             updated DataFrame.
         """
         self.fit(df[col_id])
         return super(FunctionFeaturizer, self).featurize_dataframe(
-            df, col_id, ignore_errors, return_errors, inplace)
+            df, col_id, *args, **kwargs)
 
     def generate_string_expressions(self, input_variable_names):
         """

--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -120,7 +120,8 @@ class FunctionFeaturizer(BaseFeaturizer):
         return self
 
     def featurize_dataframe(self, df, col_id, ignore_errors=False,
-                            return_errors=False, inplace=True, multiindex=False):
+                            return_errors=False, inplace=True, multiindex=False,
+                            pbar=False):
         """
         Custom featurize dataframe method that sets the column labels
         using the fit method and then featurizes the dataframe similarly

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -163,7 +163,7 @@ class TestBaseClass(PymatgenTest):
         multi_f = MultipleFeaturizer([self.single, self.multi, f])
         data = self.make_test_data()
         with warnings.catch_warnings(record=True) as w:
-            multi_f.featurize_dataframe(data, 'x')
+            multi_f.fit_featurize_dataframe(data, 'x')
             self.assertEqual(len(w), 1)
 
     def test_multifeatures(self):

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -158,13 +158,13 @@ class TestBaseClass(PymatgenTest):
         self.assertArrayAlmostEqual(data['w'], [0, 1, 2])
         self.assertArrayAlmostEqual(data['z'], [3, 4, 5])
 
-        # Test handling of Featurizers with overloaded featurize_dataframe
-        f = FunctionFeaturizer()
-        multi_f = MultipleFeaturizer([self.single, self.multi, f])
-        data = self.make_test_data()
-        with warnings.catch_warnings(record=True) as w:
-            multi_f.fit_featurize_dataframe(data, 'x')
-            self.assertEqual(len(w), 1)
+        # # Test handling of Featurizers with overloaded featurize_dataframe
+        # f = FunctionFeaturizer()
+        # multi_f = MultipleFeaturizer([self.single, self.multi, f])
+        # data = self.make_test_data()
+        # with warnings.catch_warnings(record=True) as w:
+        #     multi_f.fit_featurize_dataframe(data, 'x')
+        #     self.assertEqual(len(w), 1)
 
     def test_multifeatures(self):
         # Make a test dataset with two input variables

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -21,7 +21,7 @@ class TestFunctionFeaturizer(unittest.TestCase):
     def test_featurize(self):
         ff = FunctionFeaturizer()
         # Test basic default functionality
-        new_df = ff.featurize_dataframe(self.test_df, 'a', inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)
         # ensure NaN for undefined values
         self.assertTrue(pd.isnull(new_df['1/a'][1]))
         self.assertTrue(pd.isnull(new_df['sqrt(a)'][0]))
@@ -34,7 +34,7 @@ class TestFunctionFeaturizer(unittest.TestCase):
         # Test custom expression functionality
         expressions = ["1 / x"]
         ff = FunctionFeaturizer(expressions=expressions)
-        new_df = ff.featurize_dataframe(self.test_df, 'a', inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)
         new_df = new_df.dropna()
         self.assertTrue("1/a" in new_df.columns)
         self.assertFalse("a**2" in new_df.columns)
@@ -43,13 +43,13 @@ class TestFunctionFeaturizer(unittest.TestCase):
 
         # Test multi-functionality
         ff = FunctionFeaturizer(expressions=expressions, multi_feature_depth=2)
-        new_df = ff.featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
         new_df = new_df.dropna()
         self.assertTrue(np.allclose(new_df['1/a'] * new_df['1/b'],
                                     new_df['1/(a*b)']))
 
         ff = FunctionFeaturizer(expressions=expressions, multi_feature_depth=3)
-        new_df = ff.featurize_dataframe(self.test_df, ['a', 'b', 'c'],
+        new_df = ff.fit_featurize_dataframe(self.test_df, ['a', 'b', 'c'],
                                         inplace=False)
         new_df = new_df.dropna()
         self.assertTrue(np.allclose(new_df['1/a']*new_df['1/b']*new_df['1/c'],
@@ -58,18 +58,18 @@ class TestFunctionFeaturizer(unittest.TestCase):
         # Test complex functionality
         expressions = ["sqrt(x)"]
         ff = FunctionFeaturizer(expressions=expressions, postprocess=np.complex)
-        new_df = ff.featurize_dataframe(self.test_df, 'a', inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)
         self.assertEqual(new_df['sqrt(a)'][0], 1j)
 
         ff = FunctionFeaturizer(expressions=expressions, multi_feature_depth=2,
                                 combo_function=np.sum)
-        new_df = ff.featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
         self.assertAlmostEqual(new_df['sqrt(a) + sqrt(b)'][2], 2.41421356)
 
     def test_featurize_labels(self):
         # Test latexification
         ff = FunctionFeaturizer(latexify_labels=True)
-        new_df = ff.featurize_dataframe(self.test_df, 'a', inplace=False)
+        new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)
         self.assertTrue("\sqrt{a}" in new_df.columns)
         # Ensure error is thrown with no labels
         ff = FunctionFeaturizer(latexify_labels=False)
@@ -101,7 +101,7 @@ class TestFunctionFeaturizer(unittest.TestCase):
         ff1 = FunctionFeaturizer(expressions=["x ** 2"])
         ff2 = FunctionFeaturizer(expressions=["exp(x)", "1 / x"])
         mf = MultipleFeaturizer([ff1, ff2])
-        new_df = mf.featurize_dataframe(self.test_df, ['a', 'b', 'c'],
+        new_df = mf.fit_featurize_dataframe(self.test_df, ['a', 'b', 'c'],
                                         inplace=False)
         self.assertEqual(len(new_df), 11)
 


### PR DESCRIPTION
## Summary

Add a progress bar, fix a few minor BaseFeaturizer issues

####  Progress bar
* Added a `tqdm` progress bar (`pbar`)for single featurizers and multiplefeaturizers
* Works with featurize_many, featurize_dataframe, and fit_featurize_dataframe
* Progress bar enabled by default
* To my knowledge, works with all valid combinations of arguments to all `*_featurize_*` methods

#### Other
* Changed input signatures of featurize_dataframe for MultipleFeaturizer + FunctionFeaturizer to prevent future errors when args/kwargs added to BaseFeaturizer
* Fixed common return_errors bug which occurred when a featurizer returned a numpy array rather than a list
* Moved a print statement routed to stderr to a warning statement
* Reformatted base.py
* Removed `FunctionFeaturizer` need to overload featurize_dataframe

# Example
```
df = load_elastic_tensor().iloc[:100]
bf = BondFractions()
xrd = XRDPowderPattern()
de = DensityFeatures()
mf = MultipleFeaturizer([bf, de, xrd])
mf.fit_featurize_dataframe(df, "structure", multiindex=True, pbar=True)
```

Output:
```
BondFractions: 100%|██████████| 100/100 [00:09<00:00, 10.52it/s]
DensityFeatures: 100%|██████████| 100/100 [00:00<00:00, 628.06it/s]
XRDPowderPattern: 100%|██████████| 100/100 [00:07<00:00, 14.23it/s]
```