### PR TITLE
Added BOOP site features

### DIFF
--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -32,7 +32,8 @@ import scipy.integrate as integrate
 
 from matminer.featurizers.base import BaseFeaturizer
 from math import pi
-from scipy.spatial import Voronoi, Delaunay
+from scipy.special import sph_harm
+from sympy.physics.wigner import wigner_3j
 from pymatgen import Structure
 from pymatgen.core.periodic_table import Element
 from pymatgen.analysis.local_env import LocalStructOrderParams, \
@@ -1796,3 +1797,122 @@ class LocalPropertyDifference(BaseFeaturizer):
 
     def implementors(self):
         return ['Logan Ward']
+
+
+class BondOrientationalParameter(BaseFeaturizer):
+    """
+    Averages of spherical harmonics of local neighbors
+
+    Bond Orientational Parameters (BOPs) describe the local environment around an atom by
+    considering the local symmetry of the bonds as computed using spherical harmonics.
+    To create descriptors that are invariant to rotating the coordinate system, we use the
+    average of all spherical harmonics of a certain degree - following the approach of
+    `Steinhardt et al. <https://link.aps.org/doi/10.1103/PhysRevB.28.784>`_.
+    We weigh the contributions of each neighbor with the solid angle of the Voronoi tessellation
+    (see `Mickel et al. <https://aip.scitation.org/doi/abs/10.1063/1.4774084>_` for further
+    discussion). The weighing scheme makes these descriptors vary smoothly with small distortions
+    of a crystal structure.
+
+    In addition to the average spherical harmonics, this class can also compute the :math:`W`
+    parameters proposed by `Steinhardt et al. <https://link.aps.org/doi/10.1103/PhysRevB.28.784>`_.
+
+    Attributes:
+        BOOP Q l=<n> - Average spherical harmonic for a certain degree, n.
+        BOOP W l=<n> - W parameter for a certain degree of spherical harmonic, n.
+
+    References:
+        `Steinhardt et al., _PRB_ (1983) <https://link.aps.org/doi/10.1103/PhysRevB.28.784>`_
+        `Seko et al., _PRB_ (2017) <http://link.aps.org/doi/10.1103/PhysRevB.95.144110>`_
+    """
+
+    def __init__(self, max_l=10, compute_w=False):
+        """
+        Initialize the featurizer
+
+        Args:
+            max_l (int) - Maximum spherical harmonic to consider
+            compute_w (boolean) - Whether to compute Ws as well
+        """
+        self._nn = VoronoiNN(weight='solid_angle')
+        self.max_l = max_l
+        self.compute_W = compute_w
+
+    def featurize(self, strc, idx):
+        # Get the nearest neighbors of the atom
+        nns = get_nearest_neighbors(self._nn, strc, idx)
+
+        # Get the polar and azimuthal angles of each face
+        phi = np.arccos([x['poly_info']['normal'][-1] for x in nns])
+        theta = np.arctan2([x['poly_info']['normal'][1] for x in nns],
+                           [x['poly_info']['normal'][0] for x in nns])
+
+        # Get the weights for each neighbor
+        weights = np.array([x['weight'] for x in nns])
+        weights /= weights.sum()
+
+        # Compute the spherical harmonics for the desired `l`s
+        Qs = []
+        Ws = []
+        for l in range(1, self.max_l + 1):
+            # Average the spherical harmonic over each neighbor, weighted by solid angle
+            qlm = dict((m, np.dot(weights, sph_harm(m, l, theta, phi)))
+                       for m in range(-l, l + 1))
+
+            # Compute the average over all m's
+            Qs.append(np.sqrt(np.pi * 4 / (2 * l + 1) *
+                              np.sum(np.abs(list(qlm.values())) ** 2)))
+
+            # Compute the W, if desired
+            if self.compute_W:
+                w = 0
+                # Consider caching the Wigner coefficients, as they are expensive -lw
+                for m1, m2, m3 in _iterate_wigner_3j(l):
+                    w += qlm[m1] * qlm[m2] * qlm[m3] * float(wigner_3j(l, l, l, m1, m2, m3))
+                Ws.append(w.real)
+
+        # Return the result
+        if self.compute_W:
+            return Qs + Ws
+        return Qs
+
+    def feature_labels(self):
+        q_labels = ['BOOP Q l={}'.format(l) for l in range(1, self.max_l+1)]
+        if self.compute_W:
+            return q_labels + ['BOOP W l={}'.format(l) for l in range(1, self.max_l+1)]
+        return q_labels
+
+    def citations(self):
+        return ["@article{Seko2017,"
+                "author = {Seko, Atsuto and Hayashi, Hiroyuki and Nakayama, "
+                "Keita and Takahashi, Akira and Tanaka, Isao},"
+                "doi = {10.1103/PhysRevB.95.144110},"
+                "journal = {Physical Review B}, number = {14}, pages = {144110},"
+                "title = {{Representation of compounds for machine-learning prediction of physical properties}},"
+                "url = {http://link.aps.org/doi/10.1103/PhysRevB.95.144110},"
+                "volume = {95},year = {2017}}",
+                "@article{Steinhardt1983,"
+                "author = {Steinhardt, Paul J. and Nelson, David R. and Ronchetti, Marco},"
+                "doi = {10.1103/PhysRevB.28.784}, journal = {Physical Review B},"
+                "month = {jul}, number = {2}, pages = {784--805},"
+                "title = {{Bond-orientational order in liquids and glasses}},"
+                "url = {https://link.aps.org/doi/10.1103/PhysRevB.28.784}, "
+                "volume = {28}, year = {1983}}"]
+
+    def implementors(self):
+        return ['Logan Ward']
+
+
+def _iterate_wigner_3j(l):
+    """Iterator over all non-zero Wigner 3j triplets
+
+    Args:
+        l (int) - Desired l
+    Generates:
+        pairs of acceptable l's
+    """
+
+    for m1 in range(-l, l+1):
+        for m2 in range(-l, l+1):
+            m3 = -1 * (m1 + m2)
+            if -l <= m3 <= 1:
+                yield m1, m2, m3

--- a/matminer/featurizers/tests/test_site.py
+++ b/matminer/featurizers/tests/test_site.py
@@ -11,7 +11,8 @@ from matminer.featurizers.site import AGNIFingerprints, \
     EwaldSiteEnergy, \
     VoronoiFingerprint, ChemEnvSiteFingerprint, \
     CoordinationNumber, ChemicalSRO, GaussianSymmFunc, \
-    GeneralizedRadialDistributionFunction, AngularFourierSeries, LocalPropertyDifference
+    GeneralizedRadialDistributionFunction, AngularFourierSeries, LocalPropertyDifference, \
+    BondOrientationalParameter
 from matminer.featurizers.deprecated import CrystalSiteFingerprint
 
 
@@ -560,6 +561,24 @@ class FingerprintTests(PymatgenTest):
         for i in range(2):
             features = f.featurize(self.b1, i)
             self.assertArrayAlmostEqual(features, [1])
+
+    def test_bop(self):
+        f = BondOrientationalParameter(max_l=10, compute_w=True)
+
+        # Check the feature count
+        X_cols = f.feature_labels()
+        self.assertEqual(20, len(X_cols))
+
+        # Compute it for SC and B1
+        sc_features = f.featurize(self.sc, 0)
+        b1_features = f.featurize(self.b1, 0)
+
+        # They should be equal
+        self.assertArrayAlmostEqual(sc_features, b1_features)
+
+        # Comparing Q's to results from https://aip.scitation.org/doi/10.1063/1.4774084
+        self.assertArrayAlmostEqual([0, 0, 0, 0.764, 0, 0.354, 0, 0.718, 0, 0.411],
+                                    sc_features[:10], decimal=3)
 
     def tearDown(self):
         del self.sc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymatgen==2018.7.15
+pymatgen==2018.8.7
 pandas==0.22.0
 tqdm==4.23.1
 pymongo==3.6.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
                       'matminer.featurizers': ["*.yaml"],
                       'matminer.utils.data_files': ['*.csv', '*.tsv', '*.json', 'magpie_elementdata/*.table']},
         zip_safe=False,
-        install_requires=['pymatgen>=2018.4.20', 'tqdm>=4.14.0', 'pandas>=0.20.1',
+        install_requires=['pymatgen>=2018.8.7', 'tqdm>=4.14.0', 'pandas>=0.20.1',
                           'pymongo>=3.4.0', 'pint>=0.8.1', 'six>=1.10.0',
                           'citrination-client>=4.0.0', 'plotly>=2.4.1',
                           'mdf_forge>=0.6.1', 'scikit-learn>=0.19.0',


### PR DESCRIPTION
## Summary

Add Bond Orientational Ordering Parameters. Used by the feature set of [Seko PRB 2017](http://link.aps.org/doi/10.1103/PhysRevB.95.144110). 

Question: Does this tool already exist in pymatgen? It seems like a few different methods use BOOP parameters, but I couldn't find a general implementation.

## TODO (if any)

- Might benefit from a caching operation (noted in a line comment)
