### PR TITLE
Bug fix: Ignore errors was not working for MultiFeaturizer

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -296,7 +296,8 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
         # Run the actual featurization
         if self.n_jobs == 1:
-            return [self.featurize_wrapper(x) for x in entries]
+            return [self.featurize_wrapper(x, ignore_errors=ignore_errors,
+                                           return_errors=return_errors) for x in entries]
         else:
             if sys.version_info[0] < 3:
                 warnings.warn("Multiprocessing is not supported in "
@@ -431,7 +432,9 @@ class MultipleFeaturizer(BaseFeaturizer):
         return self
 
     def featurize_wrapper(self, x, return_errors=False, ignore_errors=False):
-        return np.hstack(np.squeeze(f.featurize_wrapper(x)) for f in self.featurizers)
+        return np.hstack(np.squeeze(f.featurize_wrapper(x, return_errors=return_errors,
+                                                        ignore_errors=ignore_errors))
+                         for f in self.featurizers)
 
     def _generate_column_labels(self, multiindex, return_errors):
         return np.hstack([f._generate_column_labels(multiindex, return_errors)

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -396,6 +396,22 @@ class TestBaseClass(PymatgenTest):
         self.assertEquals(2, _get_all_nearest_neighbors.cache_info().hits)
         self.assertEquals(2, _get_all_nearest_neighbors.cache_info().misses)
 
+    def test_ignore_errors(self):
+        # Make sure multiplefeaturizer returns the correct sub-featurizer multiindex keys
+        mf = MultipleFeaturizer([self.multi, self.single])
+
+        # Run with both serialize
+        for n in [1, 2]:
+            mf.set_n_jobs(n)
+
+            # Make sure it completes successfully
+            mf.featurize_many([['a'], [1], [2]], ignore_errors=True)
+
+            # Make sure it throws an error
+            with self.assertRaises(TypeError):
+                mf.featurize_many([['a'], [1], [2]])
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

My overhaul of MultiFeaturizer destroyed `ignore_errors` (sorry!). This PR fixes my mistakes, and adds a unit test to verify my changes actually work.

## TODO (if any)

None