### PR TITLE
Fix Issues with MultiFeaturizer and Multiple dtypes

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -421,7 +421,8 @@ class MultipleFeaturizer(BaseFeaturizer):
         self.featurizers = featurizers
 
     def featurize(self, *x):
-        return sum([list(f.featurize(*x)) for f in self.featurizers], [])
+        return np.hstack(np.squeeze([np.array(f.featurize(*x), dtype=object)
+                                     for f in self.featurizers]))
 
     def feature_labels(self):
         return sum([f.feature_labels() for f in self.featurizers], [])
@@ -432,9 +433,9 @@ class MultipleFeaturizer(BaseFeaturizer):
         return self
 
     def featurize_wrapper(self, x, return_errors=False, ignore_errors=False):
-        return sum([list(f.featurize_wrapper(x, return_errors=return_errors,
-                                             ignore_errors=ignore_errors))
-                    for f in self.featurizers], [])
+        return np.hstack([np.squeeze(np.array(f.featurize_wrapper(x, return_errors=return_errors,
+                                             ignore_errors=ignore_errors), dtype=object))
+                    for f in self.featurizers])
 
     def _generate_column_labels(self, multiindex, return_errors):
         return np.hstack([f._generate_column_labels(multiindex, return_errors)

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -421,7 +421,7 @@ class MultipleFeaturizer(BaseFeaturizer):
         self.featurizers = featurizers
 
     def featurize(self, *x):
-        return np.hstack(np.squeeze(f.featurize(*x)) for f in self.featurizers)
+        return sum([list(f.featurize(*x)) for f in self.featurizers], [])
 
     def feature_labels(self):
         return sum([f.feature_labels() for f in self.featurizers], [])
@@ -432,9 +432,9 @@ class MultipleFeaturizer(BaseFeaturizer):
         return self
 
     def featurize_wrapper(self, x, return_errors=False, ignore_errors=False):
-        return np.hstack(np.squeeze(f.featurize_wrapper(x, return_errors=return_errors,
-                                                        ignore_errors=ignore_errors))
-                         for f in self.featurizers)
+        return sum([list(f.featurize_wrapper(x, return_errors=return_errors,
+                                             ignore_errors=ignore_errors))
+                    for f in self.featurizers], [])
 
     def _generate_column_labels(self, multiindex, return_errors):
         return np.hstack([f._generate_column_labels(multiindex, return_errors)

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -1906,7 +1906,7 @@ class MaximumPackingEfficiency(BaseFeaturizer):
         max_r = [min(x['face_dist'] for x in nn.values()) for nn in nns]
 
         # Compute the packing efficiency
-        return 4. / 3. * np.pi * np.power(max_r, 3).sum() / strc.volume
+        return [4. / 3. * np.pi * np.power(max_r, 3).sum() / strc.volume]
 
     def feature_labels(self):
         return ['max packing efficiency']

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -98,6 +98,16 @@ class FittableFeaturizer(BaseFeaturizer):
         return ["A competing research group"]
 
 
+class StringFeaturizer(BaseFeaturizer):
+    """A featurizer that returns string types"""
+
+    def featurize(self, *x):
+        return ['a']
+
+    def feature_labels(self):
+        return ['label']
+
+
 class TestBaseClass(PymatgenTest):
     def setUp(self):
         self.single = SingleFeaturizer()
@@ -427,6 +437,23 @@ class TestBaseClass(PymatgenTest):
                     # Make sure it throws an error
                     with self.assertRaises(TypeError):
                         mf.featurize_many([['a'], [1], [2]])
+
+    def test_multitype_multifeat(self):
+        """Test Multifeaturizer when a featurizer returns a non-numeric type"""
+
+        # Make the featurizer
+        f = MultipleFeaturizer([SingleFeaturizer(), StringFeaturizer()])
+
+        # Make the test data
+        data = self.make_test_data()
+
+        # Add the columns
+        data = f.featurize_dataframe(data, 'x')
+
+        # Make sure the types are as expected
+        labels = f.feature_labels()
+        self.assertArrayEqual(['float64', 'object'], data[labels].dtypes.astype(str).tolist())
+        self.assertArrayAlmostEqual(data['y'], [2, 3, 4])
 
 
 if __name__ == '__main__':

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -443,6 +443,7 @@ class TestBaseClass(PymatgenTest):
 
         # Make the featurizer
         f = MultipleFeaturizer([SingleFeaturizer(), StringFeaturizer()])
+        f.set_n_jobs(1)
 
         # Make the test data
         data = self.make_test_data()
@@ -452,7 +453,7 @@ class TestBaseClass(PymatgenTest):
 
         # Make sure the types are as expected
         labels = f.feature_labels()
-        self.assertArrayEqual(['float64', 'object'], data[labels].dtypes.astype(str).tolist())
+        self.assertArrayEqual(['int64', 'object'], data[labels].dtypes.astype(str).tolist())
         self.assertArrayAlmostEqual(data['y'], [2, 3, 4])
 
 

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -98,14 +98,14 @@ class FittableFeaturizer(BaseFeaturizer):
         return ["A competing research group"]
 
 
-class StringFeaturizer(BaseFeaturizer):
-    """A featurizer that returns string types"""
+class MultiTypeFeaturizer(BaseFeaturizer):
+    """A featurizer that returns multiple dtypes"""
 
     def featurize(self, *x):
-        return ['a']
+        return ['a', 1]
 
     def feature_labels(self):
-        return ['label']
+        return ['label', 'int_label']
 
 
 class TestBaseClass(PymatgenTest):
@@ -442,7 +442,7 @@ class TestBaseClass(PymatgenTest):
         """Test Multifeaturizer when a featurizer returns a non-numeric type"""
 
         # Make the featurizer
-        f = MultipleFeaturizer([SingleFeaturizer(), StringFeaturizer()])
+        f = MultipleFeaturizer([SingleFeaturizer(), MultiTypeFeaturizer()])
         f.set_n_jobs(1)
 
         # Make the test data
@@ -453,7 +453,8 @@ class TestBaseClass(PymatgenTest):
 
         # Make sure the types are as expected
         labels = f.feature_labels()
-        self.assertArrayEqual(['int64', 'object'], data[labels].dtypes.astype(str).tolist())
+        self.assertArrayEqual(['int64', 'object', 'int64'],
+                              data[labels].dtypes.astype(str).tolist())
         self.assertArrayAlmostEqual(data['y'], [2, 3, 4])
 
 


### PR DESCRIPTION
## Summary

Should fix #289, where @albalu pointed out that the current implementation of MultiFeaturizer changes the dtypes of features if multiple types are present.

- Adds a unit test that illustrates this problem
- Preserve dtypes by using `dtype=object` when concatenating features

## TODO (if any)

None