### PR TITLE
Better Support for Pandas for featurize_many

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -286,7 +286,9 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
             return []
 
         # If the featurize function only has a single arg, zip the inputs
-        if not isinstance(entries[0], (tuple, list, np.ndarray)):
+        if isinstance(entries, pd.DataFrame):
+            entries = entries.values
+        elif isinstance(entries, pd.Series) or not isinstance(entries[0], (tuple, list, np.ndarray)):
             entries = zip(entries)
 
         # Add a progress bar

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -255,12 +255,14 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
     def featurize_many(self, entries, ignore_errors=False, return_errors=False,
                        pbar=True):
-        """
-        Featurize a list of entries.
+        """Featurize a list of entries.
+
         If `featurize` takes multiple inputs, supply inputs as a list of tuples.
 
+        Featurize_many supports entries as a list, tuple, numpy array, Pandas Series, or Pandas DataFrame.
+
         Args:
-            entries (list): A list of entries to be featurized.
+            entries (list-like object): A list of entries to be featurized.
             ignore_errors (bool): Returns NaN for entries where exceptions are
                 thrown if True. If False, exceptions are thrown as normal.
             return_errors (bool): If True, returns the feature list as
@@ -278,7 +280,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
                              " return_errors.")
 
         # Check inputs
-        if not hasattr(entries, '__getitem__'):
+        if not isinstance(entries, (tuple, list, np.ndarray, pd.Series, pd.DataFrame)):
             raise Exception("'entries' must be a list-like object")
 
         # Special case: Empty list

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -457,6 +457,18 @@ class TestBaseClass(PymatgenTest):
                               data[labels].dtypes.astype(str).tolist())
         self.assertArrayAlmostEqual(data['y'], [2, 3, 4])
 
+    def test_multifeature_no_zero_index(self):
+        """Test whether multifeaturizer can handle series that lack a entry with index==0"""
+
+        # Make a dataset without a index == 0
+        data = pd.DataFrame({'x': [1], 'y': [2]})
+        data.index = [1]
+
+        # Multifeaturize
+        self.multiargs.set_n_jobs(1)
+        self.single.featurize_many(data['x'])
+        self.multiargs.featurize_many(data[['x', 'y']])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Improves compatibility of `featurize_many` with Pandas objects. Fixes two kinds of errors:

- Using `pd.Series` crashes if there is no entry with index of `0`
- Using `pd.DataFrame` crashing if you do not first retrieve the values (e.g., `data.values`)

These errors are likely confusing to newer users, and I often ran into them. 

This PR adds a unit test that fails before the fix, and a fix for the issue.

## TODO (if any)

None