### PR TITLE
Function featurize

### DIFF
--- a/matminer/featurizers/function.py
+++ b/matminer/featurizers/function.py
@@ -186,7 +186,6 @@ class FunctionFeaturizer(BaseFeaturizer):
         return ['Joseph Montoya']
 
 
-
 # TODO: Have this filter expressions that evaluate to things without vars,
 # TODO:      # e. g. floats/ints
 def generate_expressions_combinations(expressions, combo_depth=2,
@@ -226,4 +225,6 @@ def generate_expressions_combinations(expressions, combo_depth=2,
 
     # Filter for unique combinations, also remove identity
     unique_exps = list(set(combo_exps) - {parse_expr('x0')})
+    # Sort to keep ordering
+    unique_exps = sorted(unique_exps, key=lambda x: combo_exps.index(x))
     return unique_exps

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -18,16 +18,7 @@ class TestFunctionFeaturizer(unittest.TestCase):
             [{"a": n, "b": n+1, "c": n+2} for n in range(-1, 10)])
 
     def test_featurize(self):
-        # ff = FunctionFeaturizer()
-        # df = pd.DataFrame({'t2': [2, 3, 4]})
 
-        # ff.fit(df)
-        # ff.set_n_jobs(1)
-        # serial = ff.featurize_dataframe(df, ['t2'], inplace=False)
-        # ff.set_n_jobs(2)
-        # df.drop(ff.feature_labels(), 'columns', inplace=True)
-        # parallel = ff.featurize_dataframe(df, ['t2'], inplace=False)
-        # self.assertTrue(np.allclose(serial, parallel))
         ff = FunctionFeaturizer()
         d = pd.DataFrame({'t2': [1, 2, 3]})
 
@@ -88,6 +79,16 @@ class TestFunctionFeaturizer(unittest.TestCase):
                                 combo_function=np.sum)
         new_df = ff.fit_featurize_dataframe(self.test_df, ['a', 'b'], inplace=False)
         self.assertAlmostEqual(new_df['sqrt(a) + sqrt(b)'][2], 2.41421356)
+
+        # Test parallel vs. serial
+        ff = FunctionFeaturizer()
+        df = pd.DataFrame({'t2': [1, 2, 3]})
+
+        ff.set_n_jobs(1)
+        serial = ff.fit_featurize_dataframe(df, ['t2'], inplace=False)
+        ff.set_n_jobs(2)
+        parallel = ff.fit_featurize_dataframe(df, ['t2'], inplace=False)
+        self.assertTrue(np.allclose(serial, parallel, equal_nan=True))
 
     def test_featurize_labels(self):
         # Test latexification

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -17,8 +17,31 @@ class TestFunctionFeaturizer(unittest.TestCase):
         self.test_df = pd.DataFrame(
             [{"a": n, "b": n+1, "c": n+2} for n in range(-1, 10)])
 
-
     def test_featurize(self):
+        # ff = FunctionFeaturizer()
+        # df = pd.DataFrame({'t2': [2, 3, 4]})
+
+        # ff.fit(df)
+        # ff.set_n_jobs(1)
+        # serial = ff.featurize_dataframe(df, ['t2'], inplace=False)
+        # ff.set_n_jobs(2)
+        # df.drop(ff.feature_labels(), 'columns', inplace=True)
+        # parallel = ff.featurize_dataframe(df, ['t2'], inplace=False)
+        # self.assertTrue(np.allclose(serial, parallel))
+        ff = FunctionFeaturizer()
+        d = pd.DataFrame({'t2': [1, 2, 3]})
+
+        ff.fit(d)
+
+        print(ff)
+
+        ff.set_n_jobs(1)
+        print(ff.featurize_dataframe(d, ['t2']))
+
+        ff.set_n_jobs(2)
+        d.drop(ff.feature_labels(), 'columns', inplace=True)
+        print(ff.featurize_dataframe(d, ['t2']))
+
         ff = FunctionFeaturizer()
         # Test basic default functionality
         new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -18,21 +18,6 @@ class TestFunctionFeaturizer(unittest.TestCase):
             [{"a": n, "b": n+1, "c": n+2} for n in range(-1, 10)])
 
     def test_featurize(self):
-
-        ff = FunctionFeaturizer()
-        d = pd.DataFrame({'t2': [1, 2, 3]})
-
-        ff.fit(d)
-
-        print(ff)
-
-        ff.set_n_jobs(1)
-        print(ff.featurize_dataframe(d, ['t2']))
-
-        ff.set_n_jobs(2)
-        d.drop(ff.feature_labels(), 'columns', inplace=True)
-        print(ff.featurize_dataframe(d, ['t2']))
-
         ff = FunctionFeaturizer()
         # Test basic default functionality
         new_df = ff.fit_featurize_dataframe(self.test_df, 'a', inplace=False)


### PR DESCRIPTION
## Summary

Fixes a bug in function featurizer related to scrambling of sets used to filter unique expressions.

* Fixes bug
* Adds test to test for parity between parallel and serial processing.  Note that this wasn't really the fundamental issue, but added it nonetheless, since it would have triggered the bug (at least on windows)