### PR TITLE
Ability to flatten OrbitalFieldMatrix

### DIFF
--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -646,12 +646,14 @@ class OrbitalFieldMatrix(BaseFeaturizer):
 
     Args:
         period_tag (bool): In the original OFM, an element is represented
-                by a vector of length 32, where each element is 1 or 0,
-                which represents the valence subshell of the element.
-                With period_tag=True, the vector size is increased
-                to 39, where the 7 extra elements represent the period
-                of the element. Note lanthanides are treated as period 6,
-                actinides as period 7. Default False as in the original paper.
+            by a vector of length 32, where each element is 1 or 0,
+            which represents the valence subshell of the element.
+            With period_tag=True, the vector size is increased
+            to 39, where the 7 extra elements represent the period
+            of the element. Note lanthanides are treated as period 6,
+            actinides as period 7. Default False as in the original paper.
+        flatten (bool): Flatten the avg OFM to a 1024-vector (if period_tag
+            False) or a 1521-vector (if period_tag=True).
 
     ...attribute:: size
         Either 32 or 39, the size of the vectors used to describe elements.
@@ -660,7 +662,7 @@ class OrbitalFieldMatrix(BaseFeaturizer):
         `Pham et al. _Sci Tech Adv Mat_. 2017 <http://dx.doi.org/10.1080/14686996.2017.1378060>_`
     """
 
-    def __init__(self, period_tag=False):
+    def __init__(self, period_tag=False, flatten=False):
         """Initialize the featurizer
 
         Args:
@@ -682,6 +684,7 @@ class OrbitalFieldMatrix(BaseFeaturizer):
             my_ohvs[Z] = self.get_ohv(el, period_tag)
             my_ohvs[Z] = np.matrix(my_ohvs[Z])
         self.ohvs = my_ohvs
+        self.flatten = flatten
 
     def get_ohv(self, sp, period_tag):
         """
@@ -828,10 +831,31 @@ class OrbitalFieldMatrix(BaseFeaturizer):
         s *= [3, 3, 3]
         ofms, counts = self.get_atom_ofms(s, True)
         mean_ofm = self.get_mean_ofm(ofms, counts)
-        return [mean_ofm.A]
+        if self.flatten:
+            return mean_ofm.A.flatten()
+        else:
+            return [mean_ofm.A]
 
     def feature_labels(self):
-        return ["orbital field matrix"]
+        if self.flatten:
+            slabels = ["s^{}".format(i) for i in range(1, 3)]
+            plabels = ["p^{}".format(i) for i in range(1, 7)]
+            dlabels = ["d^{}".format(i) for i in range(1, 11)]
+            flabels = ["f^{}".format(i) for i in range(1, 15)]
+            labelset_1D = slabels + plabels + dlabels + flabels
+
+            # account for period tags
+            if self.size==39:
+                period_labels = ["period {}".format(i) for i in range(1, 8)]
+                labelset_1D += period_labels
+
+            labelset_2D = []
+            for l1 in labelset_1D:
+                for l2 in labelset_1D:
+                    labelset_2D.append('OFM: ' + l1 + ' - ' + l2)
+            return labelset_2D
+        else:
+            return ["orbital field matrix"]
 
     def citations(self):
         return ["@article{LamPham2017,"
@@ -850,7 +874,7 @@ class OrbitalFieldMatrix(BaseFeaturizer):
                 "}"]
 
     def implementors(self):
-        return ["Kyle Bystrom"]
+        return ["Kyle Bystrom", "Alex Dunn"]
 
 
 class MinimumRelativeDistances(BaseFeaturizer):

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -308,7 +308,7 @@ class StructureFeaturesTest(PymatgenTest):
         self.assertEqual(len(ofm_flat.feature_labels()), 1521)
         ofm_vector = ofm_flat.featurize(self.diamond)
         for ix in [40, 42, 72, 118, 120, 150, 1288, 1320]:
-            self.assertEqual(ofm_vector[ix], 1.4789015345821415)
+            self.assertAlmostEqual(ofm_vector[ix], 1.4789015345821415)
 
     def test_min_relative_distances(self):
         self.assertAlmostEqual(MinimumRelativeDistances().featurize(

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -301,6 +301,15 @@ class StructureFeaturesTest(PymatgenTest):
         self.assertAlmostEqual(
             np.linalg.norm(ofm - mtarget), 0.0, places=4)
 
+        ofm_flat = OrbitalFieldMatrix(period_tag=False, flatten=True)
+        self.assertEqual(len(ofm_flat.feature_labels()), 1024)
+
+        ofm_flat = OrbitalFieldMatrix(period_tag=True, flatten=True)
+        self.assertEqual(len(ofm_flat.feature_labels()), 1521)
+        ofm_vector = ofm_flat.featurize(self.diamond)
+        for ix in [40, 42, 72, 118, 120, 150, 1288, 1320]:
+            self.assertEqual(ofm_vector[ix], 1.4789015345821415)
+
     def test_min_relative_distances(self):
         self.assertAlmostEqual(MinimumRelativeDistances().featurize(
                 self.diamond_no_oxi)[0][0], 1.1052576)


### PR DESCRIPTION
## Summary

Adds an option to flatten the OFM of fixed size (either 32x32 or 39x39) to a fixed length vector (1024 or 1521). This might make it easier to input into ML models. The difference is:

**Matrix**
```python
>>> df = load_elastic_tensor()[:2][["structure", "formula"]]
>>>OrbitalFieldMatrix(flatten=False).featurize_dataframe(df)
structure    formula                               orbital field matrix
0  [[0.94814328 2.07280467 2.5112    ] Nb, [5.273...    Nb4CoSi  [[0.5890106964309796, 0.5152901102725697, 0.0,...
1  [[0. 0. 0.] Al, [1.96639263 1.13529553 0.75278...  Al(CoSi)2  [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,...
```

vs.

**Flat**
```python
>>> df = load_elastic_tensor()[:2][["structure", "formula"]]
>>>OrbitalFieldMatrix(flatten=True).featurize_dataframe(df)
                                           structure    formula  OFM: s^1 - s^1  OFM: s^1 - s^2  OFM: s^1 - p^1  OFM: s^1 - p^2  OFM: s^1 - p^3  OFM: s^1 - p^4  OFM: s^1 - p^5  OFM: s^1 - p^6  \
0  [[0.94814328 2.07280467 2.5112    ] Nb, [5.273...    Nb4CoSi        0.589011         0.51529             0.0        0.244162             0.0             0.0             0.0             0.0   
1  [[0. 0. 0.] Al, [1.96639263 1.13529553 0.75278...  Al(CoSi)2        0.000000         0.00000             0.0        0.000000             0.0             0.0             0.0             0.0 

...

   OFM: f^14 - f^6  OFM: f^14 - f^7  OFM: f^14 - f^8  OFM: f^14 - f^9  OFM: f^14 - f^10  OFM: f^14 - f^11  OFM: f^14 - f^12  OFM: f^14 - f^13  OFM: f^14 - f^14  
0              0.0              0.0              0.0              0.0               0.0               0.0               0.0               0.0               0.0  
1              0.0              0.0              0.0              0.0               0.0               0.0               0.0               0.0               0.0 
```

Also includes some tests to support this flattened case.
