### PR TITLE
fractional compositions in AtomicOrbitals

### DIFF
--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -317,9 +317,9 @@ class AtomicOrbitals(BaseFeaturizer):
                 the estimated bandgap from HOMO and LUMO energeis
         """
 
-        string_comp = comp.reduced_formula
+        integer_comp, factor = comp.get_integer_formula_and_factor()
 
-        homo_lumo = MolecularOrbitals(string_comp).band_edges
+        homo_lumo = MolecularOrbitals(integer_comp).band_edges
 
         feat = collections.OrderedDict()
         for edge in ['HOMO', 'LUMO']:

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -4,6 +4,7 @@ import collections
 import itertools
 import os
 from functools import reduce, lru_cache
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -294,10 +295,18 @@ class AtomicOrbitals(BaseFeaturizer):
     """
     Determine HOMO/LUMO features based on a composition.
 
-    Determine the highest occupied molecular orbital (HOMO) and
-    lowest unoccupied molecular orbital (LUMO) in a composition. The atomic
-    orbital energies of neutral ions with LDA-DFT were computed by NIST.
+    The highest occupied molecular orbital (HOMO) and lowest unoccupied
+    molecular orbital (LUMO) are estiated from the atomic orbital energies
+    of the composition. The atomic orbital energies are from NIST:
     https://www.nist.gov/pml/data/atomic-reference-data-electronic-structure-calculations
+
+    Warning:
+    For compositions with inter-species fractions greater than 10,000 (e.g.
+    dilute alloys such as FeC0.00001) the composition will be truncated (to Fe
+    in this example). In such extreme cases, the truncation likely reflects the
+    true physics of the situation (i.e. that the dilute element does not
+    significantly contribute orbital character to the band structure), but the
+    user should be aware of this behavior.
     """
 
     def featurize(self, comp):
@@ -318,6 +327,12 @@ class AtomicOrbitals(BaseFeaturizer):
         """
 
         integer_comp, factor = comp.get_integer_formula_and_factor()
+
+        # warning message if composition is dilute and truncated
+        if not (len(Composition(comp).elements) ==
+                len(Composition(integer_comp).elements)):
+            warn('AtomicOrbitals: {} truncated to {}'.format(comp,
+                                                             integer_comp))
 
         homo_lumo = MolecularOrbitals(integer_comp).band_edges
 

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -143,6 +143,11 @@ class CompositionFeaturesTest(PymatgenTest):
         self.assertEqual(df_atomic_orbitals['LUMO_energy'][0], -0.295049)
         self.assertEqual(df_atomic_orbitals['gap_AO'][0], 0.0)
 
+        # test that fractional compositions return the same features
+        self.assertEqual(AtomicOrbitals().featurize(Composition('Na0.5Cl0.5')),
+                         AtomicOrbitals().featurize(Composition('NaCl')))
+
+
     def test_band_center(self):
         df_band_center = BandCenter().featurize_dataframe(self.df, col_id="composition")
         self.assertAlmostEqual(df_band_center["band center"][0], -2.672486385)

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals, division, print_function
 
 import math
 import unittest
+import warnings
 from unittest import SkipTest
 
 import pandas as pd
@@ -146,6 +147,10 @@ class CompositionFeaturesTest(PymatgenTest):
         # test that fractional compositions return the same features
         self.assertEqual(AtomicOrbitals().featurize(Composition('Na0.5Cl0.5')),
                          AtomicOrbitals().featurize(Composition('NaCl')))
+
+        # test if warning is raised upon composition truncation in dilute cases
+        self.assertWarns(UserWarning, AtomicOrbitals().featurize,
+                         Composition('Fe1C0.00000001'))
 
 
     def test_band_center(self):


### PR DESCRIPTION

## Summary

- add "sanitation" step to `AtomicOrbitals` composition featurizer
- fractional compositions (Na0.5Cl0.5) are now supported
- added test to ensure equivalent compositions (NaCl v.s. Na0.5Cl0.5) return the same features

## TODO
- possibly update pymatgen.core.MolecularOrbitals to require integer subscripts