### PR TITLE
Bug fix for AtomicPackingEfficiency

### DIFF
--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -1604,6 +1604,7 @@ class AtomicPackingEfficiency(BaseFeaturizer):
             # Get the nearest clusters
             if cluster_lookup is None:
                 dists = (np.array([]),)
+                to_lookup = 0
             else:
                 to_lookup = min(cluster_lookup._fit_X.shape[0], k)
                 dists, _ = cluster_lookup.kneighbors([comp_vec], to_lookup)

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -298,5 +298,9 @@ class CompositionFeaturesTest(PymatgenTest):
         self.assertAlmostEqual(0.003508794,
                                df['mean abs simul. packing efficiency'][0])
 
+        # Make sure it works with composition that do not match any efficient clusters
+        feat = f.compute_nearest_cluster_distance(Composition('Al'))
+        self.assertArrayAlmostEqual([1]*3, feat)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

It previously crashed when no efficiently-packed clusters are found for a particular system. I added a unit test that fails before the fix and a fix

## TODO (if any)

None