### PR TITLE
Minor: BandCenter for stoichiometry with large coefficients

### DIFF
--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -389,11 +389,11 @@ class BandCenter(BaseFeaturizer):
             (float) band center.
 
         """
-        prod = 1.0
+        gmean = 1.0
+        sumamt = sum(comp.get_el_amt_dict().values())
         for el, amt in comp.get_el_amt_dict().items():
-            prod = prod * (Element(el).X ** amt)
-
-        return [-prod ** (1 / sum(comp.get_el_amt_dict().values()))]
+            gmean *= Element(el).X**(amt/sumamt)
+        return -gmean
 
     def feature_labels(self):
         return ["band center"]

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -156,6 +156,8 @@ class CompositionFeaturesTest(PymatgenTest):
     def test_band_center(self):
         df_band_center = BandCenter().featurize_dataframe(self.df, col_id="composition")
         self.assertAlmostEqual(df_band_center["band center"][0], -2.672486385)
+        self.assertAlmostEqual(
+            BandCenter().featurize(Composition('Ag33O500V200')), -2.7337150991)
 
     def test_oxidation_states(self):
         featurizer = OxidationStates.from_preset("deml")


### PR DESCRIPTION
Stoichiometry with large coefficients would break the previous BandCenter since the X's were raised to sum of coefficients first and then raised to 1/sum in the geometric mean calculations.