### PR TITLE
Add chunksize support to BaseFeaturizer

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -104,14 +104,16 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     itself. For computationally expensive featurizers, the default
     chunksize of 1 will be the most efficient. However, for more lightweight
     featurizers, it is recommended that the implementor trial a range of
-    chunksize values to find the optimum.
+    chunksize values to find the optimum. As a general rule of thumb, if the
+    featurize function takes 0.1 seconds or less, a chunksize of around 30 will
+    perform best. For longer featurize times, a chunksize of 1 should be used.
 
     ## Documenting a BaseFeaturizer
 
     The class documentation for each featurizer must contain a description of
     the options and the features that will be computed. The options of the class
-     must all be defined in the `__init__` function of the class, and we
-     recommend documenting them using the
+    must all be defined in the `__init__` function of the class, and we
+    recommend documenting them using the
     [Google style](https://google.github.io/styleguide/pyguide.html).
 
     For auto-generated documentation purposes, the first line of the featurizer

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -93,6 +93,19 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     call `featurize`. See `PartialRadialDistributionFunction` for an example of
     this concept.
 
+    An additional factor to consider is the chunksize for data parallelisation.
+    For lightweight computational tasks, the overhead associated with passing
+    data from `multiprocessing.Pool.map()` to the function being parallelised
+    can increase the time taken for all tasks to be completed. By setting
+    the `self._chunksize` argument, the overhead associated with passing data
+    to the tasks can be reduced. Note that there is only an advantage to using
+    chunksize when the time taken to pass the data from `map` to the function
+    call is within several orders of magnitude to that of the function call
+    itself. For computationally expensive featurizers, the default
+    chunksize of 1 will be the most efficient. However, for more lightweight
+    featurizers, it is recommended that the implementor trial a range of
+    chunksize values to find the optimum.
+
     ## Documenting a BaseFeaturizer
 
     The class documentation for each featurizer must contain a description of
@@ -125,6 +138,10 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     @property
     def n_jobs(self):
         return self._n_jobs if hasattr(self, '_n_jobs') else cpu_count()
+
+    def set_chunksize(self, chunksize):
+        """Set the chunksize used for Pool.map parallelisation."""
+        self._chunksize = chunksize
 
     @property
     def chunksize(self):

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -126,6 +126,10 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     def n_jobs(self):
         return self._n_jobs if hasattr(self, '_n_jobs') else cpu_count()
 
+    @property
+    def chunksize(self):
+        return self._chunksize if hasattr(self, '_chunksize') else 1
+
     def fit(self, X, y=None, **fit_kwargs):
         """Update the parameters of this featurizer based on available data
 
@@ -321,9 +325,10 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
                                            return_errors=return_errors,
                                            pbar=pbar)
             with Pool(self.n_jobs) as p:
-                func = partial(self.featurize_wrapper, return_errors=return_errors,
+                func = partial(self.featurize_wrapper,
+                               return_errors=return_errors,
                                ignore_errors=ignore_errors)
-                return p.map(func, entries)
+                return p.map(func, entries, chunksize=self.chunksize)
 
     def featurize_wrapper(self, x, return_errors=False, ignore_errors=False):
         """

--- a/matminer/featurizers/conversions.py
+++ b/matminer/featurizers/conversions.py
@@ -132,7 +132,7 @@ class StrToComposition(ConversionFeaturizer):
                  overwrite_data=False):
         super().__init__(target_col_id, overwrite_data)
         self.reduce = reduce
-        self._chunksize = 20
+        self._chunksize = 30
 
     def featurize(self, string_composition):
         """Convert a string to a pymatgen Composition.
@@ -190,7 +190,7 @@ class StructureToComposition(ConversionFeaturizer):
         super().__init__(target_col_id, overwrite_data)
         self.reduce = reduce
         self._overwrite = overwrite_data
-        self._chunksize = 20
+        self._chunksize = 30
 
     def featurize(self, structure):
         """Convert a string to a pymatgen Composition.
@@ -246,7 +246,7 @@ class StructureToIStructure(ConversionFeaturizer):
     def __init__(self, target_col_id='istructure', overwrite_data=False):
         super().__init__(target_col_id, overwrite_data)
         self._overwrite = overwrite_data
-        self._chunksize = 20
+        self._chunksize = 30
 
     def featurize(self, structure):
         """Convert a pymatgen Structure to an immutable IStructure,
@@ -294,7 +294,7 @@ class DictToObject(ConversionFeaturizer):
 
     def __init__(self, target_col_id='_object', overwrite_data=False):
         super().__init__(target_col_id, overwrite_data)
-        self._chunksize = 20
+        self._chunksize = 30
 
     def featurize(self, dict_data):
         """Convert a string to a pymatgen Composition.
@@ -343,7 +343,7 @@ class JsonToObject(ConversionFeaturizer):
 
     def __init__(self, target_col_id='_object', overwrite_data=False):
         super().__init__(target_col_id, overwrite_data)
-        self._chunksize = 20
+        self._chunksize = 30
 
     def featurize(self, json_data):
         """Convert a string to a pymatgen Composition.

--- a/matminer/featurizers/conversions.py
+++ b/matminer/featurizers/conversions.py
@@ -132,6 +132,7 @@ class StrToComposition(ConversionFeaturizer):
                  overwrite_data=False):
         super().__init__(target_col_id, overwrite_data)
         self.reduce = reduce
+        self._chunksize = 20
 
     def featurize(self, string_composition):
         """Convert a string to a pymatgen Composition.
@@ -189,6 +190,7 @@ class StructureToComposition(ConversionFeaturizer):
         super().__init__(target_col_id, overwrite_data)
         self.reduce = reduce
         self._overwrite = overwrite_data
+        self._chunksize = 20
 
     def featurize(self, structure):
         """Convert a string to a pymatgen Composition.
@@ -244,6 +246,7 @@ class StructureToIStructure(ConversionFeaturizer):
     def __init__(self, target_col_id='istructure', overwrite_data=False):
         super().__init__(target_col_id, overwrite_data)
         self._overwrite = overwrite_data
+        self._chunksize = 20
 
     def featurize(self, structure):
         """Convert a pymatgen Structure to an immutable IStructure,
@@ -291,6 +294,7 @@ class DictToObject(ConversionFeaturizer):
 
     def __init__(self, target_col_id='_object', overwrite_data=False):
         super().__init__(target_col_id, overwrite_data)
+        self._chunksize = 20
 
     def featurize(self, dict_data):
         """Convert a string to a pymatgen Composition.
@@ -339,6 +343,7 @@ class JsonToObject(ConversionFeaturizer):
 
     def __init__(self, target_col_id='_object', overwrite_data=False):
         super().__init__(target_col_id, overwrite_data)
+        self._chunksize = 20
 
     def featurize(self, json_data):
         """Convert a string to a pymatgen Composition.


### PR DESCRIPTION
## Summary

`multiprocessing.Pool.map` supports the `chunksize` argument which determines how many entries are given to each processor simultaneously. For lightweight computational tasks, the overhead associated with passing data from `map` to the function being parallelised can dramatically increase the time taken for all tasks to be completed. By using the `chunksize` argument, the overhead associated with passing data to the tasks can be reduced. Note that there is only an advantage to using `chunksize` when the time take to pass the data from map to the function call is within several orders of magnitude to the time taken for the function call itself.

For the heavy featurizers such as `MinimumPackingEfficiency`, the chunksize should be set to 1 for maximum efficiency. However, for lightweight featurizers, such as some of the conversion featurizers, it is generally beneficial to use a `chunksize` greater than 1.

I've implemented support for `chunksize` in `BaseFeaturizer` and set a `chunksize` of 20 in the lightweight conversion featurizers. In my testing this was an optimal value and increased conversion times by 50-70%.

If anyone has a feeling for other featurizers that are very lightweight, please let me know and I can have a look at tuning chunksize for them.