### PR TITLE
Use tqdm notebook progress bar in IPython Notebooks

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -10,9 +10,9 @@ import numpy as np
 import pandas as pd
 from six import string_types, reraise
 from sklearn.base import TransformerMixin, BaseEstimator, is_classifier
-from tqdm import tqdm
+import tqdm
 
-from matminer.utils.utils import homogenize_multiindex
+from matminer.utils.utils import homogenize_multiindex, is_notebook
 
 
 class BaseFeaturizer(BaseEstimator, TransformerMixin):
@@ -301,8 +301,12 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
         # Add a progress bar
         if pbar:
+            if is_notebook():
+                tqdm_func = tqdm.tqdm_notebook
+            else:
+                tqdm_func = tqdm.tqdm
             # list() required, tqdm has issues with memory if generator given
-            entries = tqdm(list(entries), desc=self.__class__.__name__)
+            entries = tqdm_func(list(entries), desc=self.__class__.__name__)
 
         # Run the actual featurization
         if self.n_jobs == 1:

--- a/matminer/utils/utils.py
+++ b/matminer/utils/utils.py
@@ -36,3 +36,18 @@ def homogenize_multiindex(df, default_key, coerce=False):
         raise IndexError("An input dataframe of 2+ levels cannot be used for"
                          "multiindexed Matminer featurization without coercion "
                          "to 2 levels.")
+
+
+def is_notebook():
+    """Check if python is running in an interactive notebook.
+
+    Adapted from: https://stackoverflow.com/questions/47211324/check-if-module-is-running-in-jupyter-or-not
+    """
+    try:
+        ipy_str = str(type(get_ipython()))
+        if 'zmqshell' in ipy_str:
+            return True
+        if 'terminal' in ipy_str:
+            return False
+    except NameError:
+        return False


### PR DESCRIPTION
## Summary

The progress bar package used in matminer (`tqdm`) has a prettier progress bar specifically for IPython notebooks. As matminer is mostly used via notebooks, it seems like a nice idea to use the notebook-specific progress bar when possible. 

Changes made:
- I've added a function to check whether python is currently running within a notebook.
- If in a notebook, `tqdm_notebook` will be used instead of just `tqdm`.