### PR TITLE
Improved support for multiindex in conversion featurizers

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -253,7 +253,21 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
         # Add columns for the errors from the featurizer
         if return_errors:
             labels.append(self.__class__.__name__ + " Exceptions")
-        if multiindex:
+
+        if multiindex and len(labels[0]) == 2:
+            # conversion featurizer, aiming to featurize in place.
+            # conversion featurizers only have one feature label.
+            # If return_errors=False, the transformation is:
+            # [('l1', 'l2')] -> [('l1', 'l2')] (i.e. unaltered).
+            # But if return_errors=True, the transformation is:
+            # [('l1', 'l2'), 'feat Exceptions'] ->
+            # [('l1', 'l2'), ('l1', 'feat Exceptions')]
+            tmp_labels = [label if isinstance(label, str) else label[1]
+                          for label in labels]
+            indices = ([labels[0][0]], tmp_labels)
+            labels = pd.MultiIndex.from_product(indices)
+
+        elif multiindex:
             indices = ([self.__class__.__name__], labels)
             labels = pd.MultiIndex.from_product(indices)
         return labels

--- a/matminer/featurizers/conversions.py
+++ b/matminer/featurizers/conversions.py
@@ -73,12 +73,6 @@ class ConversionFeaturizer(BaseFeaturizer):
         Returns:
             (Pandas.Dataframe): The updated dataframe.
         """
-
-        # TODO: Figure out if this is possible/desired
-        if 'multiiindex' in kwargs and kwargs['multiindex']:
-            raise ValueError("ConversionFeaturizer does not support "
-                             "multiindexing")
-
         # now the col_id is known, we check if we need to update target_col_id
         # for multiindexes it is the last index that is updated
         target = self._target_col_id

--- a/matminer/featurizers/tests/test_conversions.py
+++ b/matminer/featurizers/tests/test_conversions.py
@@ -166,6 +166,31 @@ class TestConversions(TestCase):
         self.assertEqual(df_2lvl[("StrToComposition", "test")].tolist(),
                          [Composition("Fe2"), Composition("MnO2")])
 
+        # if two level multiindex provided as target, it should be written there
+        # here we test converting multiindex in place
+        df_2lvl = DataFrame(data=d)
+        df_2lvl.columns = MultiIndex.from_product((["custom"],
+                                                   df_2lvl.columns.values))
+
+        sto = StrToComposition(target_col_id=None, overwrite_data=True)
+        df_2lvl = sto.featurize_dataframe(
+            df_2lvl, ("custom", "comp_str"), multiindex=True)
+        self.assertEqual(df_2lvl[("custom", "comp_str")].tolist(),
+                         [Composition("Fe2"), Composition("MnO2")])
+
+        # Try inplace multiindex conversion with return errors
+        df_2lvl = DataFrame(data=d)
+        df_2lvl.columns = MultiIndex.from_product((["custom"],
+                                                   df_2lvl.columns.values))
+
+        sto = StrToComposition(target_col_id=None, overwrite_data=True)
+        df_2lvl = sto.featurize_dataframe(
+            df_2lvl, ("custom", "comp_str"), multiindex=True,
+            return_errors=True, ignore_errors=True
+        )
+        self.assertTrue(
+            all(df_2lvl[("custom", "StrToComposition Exceptions")].isnull()))
+
     def test_conversion_multiindex_dynamic(self):
         # test dynamic target_col_id setting with multiindex
 


### PR DESCRIPTION
## Summary

Fixed a bug where conversion featurizers were unable to convert data in place with multiindex DataFrames.

The new implementation should be robust to conversion featurizers that add multiple converted columns (should this ever happen). There is also support for `return_errors=True`, when using conversion featurizers on multiindex DataFrames.