### PR TITLE
Deprecation and compatibility fixes

### DIFF
--- a/matminer/data_retrieval/retrieve_Citrine.py
+++ b/matminer/data_retrieval/retrieve_Citrine.py
@@ -78,7 +78,7 @@ class CitrineDataRetrieval(BaseDataRetrieval):
             properties = list(set(properties))
         all_fields = []
         for prop_counter, requested_prop in enumerate(properties):
-            jsons = self.get_data(**criteria, prop=requested_prop)
+            jsons = self.get_data(prop=requested_prop, **criteria)
             non_prop_df = pd.DataFrame()  # df w/o measurement column
             prop_df = pd.DataFrame()  # df containing only measurement column
             counter = 0  # variable to keep count of sample hit and set indexes
@@ -110,7 +110,7 @@ class CitrineDataRetrieval(BaseDataRetrieval):
                             # Rename property name according to above duplicate numbering
                             prop["name"] = all_prop_names[p_idx]
                             if "scalars" in prop:
-                                p_df.set_value(counter, prop["name"], parse_scalars(prop["scalars"]))
+                                p_df.at[counter, prop["name"]] = parse_scalars(prop["scalars"])
                             elif "vectors" in prop:
                                 p_df[prop["name"]] = prop["vectors"]
                             elif "matrices" in prop:
@@ -123,11 +123,11 @@ class CitrineDataRetrieval(BaseDataRetrieval):
                                         p_df[prop["name"] + "-" + prop_key] = np.nan
                                         p_df[prop["name"] + "-" + prop_key] = \
                                             p_df[prop["name"] + "-" + prop_key].astype(object)
-                                    p_df.set_value(counter, prop["name"] + "-" + prop_key, prop[prop_key])
+                                    p_df.at[counter, prop["name"] + "-" + prop_key] = prop[prop_key]
                         p_df.index = [counter]
                         prop_df = prop_df.append(p_df)
             df_prop = pd.concat([non_prop_df, prop_df], axis=1)
-            if prop_counter==0:
+            if prop_counter == 0:
                 optcomcols = df_prop.columns.values
             else:
                 optcomcols = list(set(optcomcols) & set(df_prop.columns))

--- a/matminer/data_retrieval/retrieve_MPDS.py
+++ b/matminer/data_retrieval/retrieve_MPDS.py
@@ -10,7 +10,11 @@ from matminer.data_retrieval.retrieve_base import BaseDataRetrieval
 from six.moves.urllib_parse import urlencode
 
 import httplib2
-import ujson as json
+
+try:
+    import ujson as json
+except ImportError:
+    import json
 
 import pandas as pd
 

--- a/matminer/data_retrieval/tests/test_retrieve_Citrine.py
+++ b/matminer/data_retrieval/tests/test_retrieve_Citrine.py
@@ -19,8 +19,8 @@ class CitrineDataRetrievalTest(unittest.TestCase):
         self.cdr = CitrineDataRetrieval(citrine_key)
 
     def test_get_data(self):
-        pifs_lst = self.cdr.get_api_data(formula="W", data_type='EXPERIMENTAL',
-                                         max_results=10)
+        pifs_lst = self.cdr.get_data(formula="W", data_type='EXPERIMENTAL',
+                                     max_results=10)
         self.assertEqual(len(pifs_lst), 10)
         df = self.cdr.get_dataframe(criteria={'formula':'W',
                                               'data_type':'EXPERIMENTAL',

--- a/matminer/data_retrieval/tests/test_retrieve_MPDS.py
+++ b/matminer/data_retrieval/tests/test_retrieve_MPDS.py
@@ -1,5 +1,8 @@
 import httplib2
-import ujson as json
+try:
+    import ujson as json
+except ImportError:
+    import json
 import unittest
 from jsonschema import validate, Draft4Validator
 from jsonschema.exceptions import ValidationError

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -342,7 +342,7 @@ class OPSiteFingerprint(BaseFeaturizer):
             # print('{} {} {}'.format(minval, maxval, nbins))
             hist, bin_edges = np.histogram(
                 op_tmp, bins=nbins, range=(minval, maxval),
-                normed=False, weights=None, density=False)
+                weights=None, density=False)
             max_hist = max(hist)
             op_peaks = []
             for i, h in enumerate(hist):

--- a/matminer/featurizers/structure.py
+++ b/matminer/featurizers/structure.py
@@ -604,7 +604,8 @@ class SineCoulombMatrix(BaseFeaturizer):
                     vec = coords[i] - coords[j]
                     coord_vec = np.sin(pi * vec) ** 2
                     trig_dist = np.linalg.norm(
-                        (np.matrix(coord_vec) * lattice).A1) * ANG_TO_BOHR
+                        np.dot(coord_vec, lattice).flatten()
+                    ) * ANG_TO_BOHR
                     sin_mat[i][j] = Zs[i] * Zs[j] / trig_dist
                 else:
                     sin_mat[i][j] = sin_mat[j][i]
@@ -683,7 +684,6 @@ class OrbitalFieldMatrix(BaseFeaturizer):
         for Z in range(1, 95):
             el = Element.from_Z(Z)
             my_ohvs[Z] = self.get_ohv(el, period_tag)
-            my_ohvs[Z] = np.matrix(my_ohvs[Z])
         self.ohvs = my_ohvs
         self.flatten = flatten
 
@@ -754,10 +754,10 @@ class OrbitalFieldMatrix(BaseFeaturizer):
             site_dict (dict of Site:float): chemical environment
 
         Returns:
-            atom_ofm (size X size numpy matrix): ofm for site
+            atom_ofm (size X size numpy array): ofm for site
         """
         ohvs = self.ohvs
-        atom_ofm = np.matrix(np.zeros((self.size, self.size)))
+        atom_ofm = np.zeros((self.size, self.size))
         ref_atom = ohvs[site.specie.Z]
         for other_site in site_dict:
             scale = other_site['weight']

--- a/matminer/featurizers/tests/test_function.py
+++ b/matminer/featurizers/tests/test_function.py
@@ -111,7 +111,7 @@ class TestFunctionFeaturizer(unittest.TestCase):
         ff2 = FunctionFeaturizer(expressions=["exp(x)", "1 / x"])
         mf = MultipleFeaturizer([ff1, ff2])
         new_df = mf.fit_featurize_dataframe(self.test_df, ['a', 'b', 'c'],
-                                        inplace=False)
+                                            inplace=False)
         self.assertEqual(len(new_df), 11)
 
 

--- a/matminer/featurizers/tests/test_site.py
+++ b/matminer/featurizers/tests/test_site.py
@@ -131,36 +131,37 @@ class FingerprintTests(PymatgenTest):
         self.assertEqual(len([1 for l in opsfp.feature_labels() if l.split()[0] == 'wt']), 0)
 
     def test_crystal_site_fingerprint(self):
-        csf = CrystalSiteFingerprint.from_preset('ops')
-        l = csf.feature_labels()
-        t = ['wt CN_1', 'wt CN_2', 'L-shaped CN_2', 'water-like CN_2', \
-             'bent 120 degrees CN_2', 'bent 150 degrees CN_2', 'linear CN_2', \
-             'wt CN_3', 'trigonal planar CN_3', 'trigonal non-coplanar CN_3', \
-             'T-shaped CN_3', 'wt CN_4', 'square co-planar CN_4', \
-             'tetrahedral CN_4', 'rectangular see-saw-like CN_4', \
-             'see-saw-like CN_4', 'trigonal pyramidal CN_4', 'wt CN_5', \
-             'pentagonal planar CN_5', 'square pyramidal CN_5', \
-             'trigonal bipyramidal CN_5', 'wt CN_6', 'hexagonal planar CN_6', \
-             'octahedral CN_6', 'pentagonal pyramidal CN_6', 'wt CN_7', \
-             'hexagonal pyramidal CN_7', 'pentagonal bipyramidal CN_7', \
-             'wt CN_8', 'body-centered cubic CN_8', \
-             'hexagonal bipyramidal CN_8', 'wt CN_9', 'q2 CN_9', 'q4 CN_9', \
-             'q6 CN_9', 'wt CN_10', 'q2 CN_10', 'q4 CN_10', 'q6 CN_10', \
-             'wt CN_11', 'q2 CN_11', 'q4 CN_11', 'q6 CN_11', 'wt CN_12', \
-             'cuboctahedral CN_12', 'q2 CN_12', 'q4 CN_12', 'q6 CN_12']
-        for i in range(len(l)):
-            self.assertEqual(l[i], t[i])
-        ops = csf.featurize(self.sc, 0)
-        self.assertEqual(len(ops), 48)
-        self.assertAlmostEqual(ops[csf.feature_labels().index(
-            'wt CN_6')], 1, places=4)
-        self.assertAlmostEqual(ops[csf.feature_labels().index(
-            'octahedral CN_6')], 1, places=4)
-        ops = csf.featurize(self.cscl, 0)
-        self.assertAlmostEqual(ops[csf.feature_labels().index(
-            'wt CN_8')], 0.5575257, places=4)
-        self.assertAlmostEqual(ops[csf.feature_labels().index(
-            'body-centered cubic CN_8')], 0.5329344, places=4)
+        with self.assertWarns(DeprecationWarning):
+            csf = CrystalSiteFingerprint.from_preset('ops')
+            l = csf.feature_labels()
+            t = ['wt CN_1', 'wt CN_2', 'L-shaped CN_2', 'water-like CN_2',
+                 'bent 120 degrees CN_2', 'bent 150 degrees CN_2', 'linear CN_2',
+                 'wt CN_3', 'trigonal planar CN_3', 'trigonal non-coplanar CN_3',
+                 'T-shaped CN_3', 'wt CN_4', 'square co-planar CN_4',
+                 'tetrahedral CN_4', 'rectangular see-saw-like CN_4',
+                 'see-saw-like CN_4', 'trigonal pyramidal CN_4', 'wt CN_5',
+                 'pentagonal planar CN_5', 'square pyramidal CN_5',
+                 'trigonal bipyramidal CN_5', 'wt CN_6', 'hexagonal planar CN_6',
+                 'octahedral CN_6', 'pentagonal pyramidal CN_6', 'wt CN_7',
+                 'hexagonal pyramidal CN_7', 'pentagonal bipyramidal CN_7',
+                 'wt CN_8', 'body-centered cubic CN_8',
+                 'hexagonal bipyramidal CN_8', 'wt CN_9', 'q2 CN_9', 'q4 CN_9',
+                 'q6 CN_9', 'wt CN_10', 'q2 CN_10', 'q4 CN_10', 'q6 CN_10',
+                 'wt CN_11', 'q2 CN_11', 'q4 CN_11', 'q6 CN_11', 'wt CN_12',
+                 'cuboctahedral CN_12', 'q2 CN_12', 'q4 CN_12', 'q6 CN_12']
+            for i in range(len(l)):
+                self.assertEqual(l[i], t[i])
+            ops = csf.featurize(self.sc, 0)
+            self.assertEqual(len(ops), 48)
+            self.assertAlmostEqual(ops[csf.feature_labels().index(
+                'wt CN_6')], 1, places=4)
+            self.assertAlmostEqual(ops[csf.feature_labels().index(
+                'octahedral CN_6')], 1, places=4)
+            ops = csf.featurize(self.cscl, 0)
+            self.assertAlmostEqual(ops[csf.feature_labels().index(
+                'wt CN_8')], 0.5575257, places=4)
+            self.assertAlmostEqual(ops[csf.feature_labels().index(
+                'body-centered cubic CN_8')], 0.5329344, places=4)
 
     def test_crystal_nn_fingerprint(self):
         cnnfp = CrystalNNFingerprint.from_preset(

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -279,9 +279,8 @@ class StructureFeaturesTest(PymatgenTest):
         mtarget[3][3] = 1.4789015  # 1.3675444 if for a coord# of exactly 4
         for i in range(32):
             for j in range(32):
-                if not i in [1, 3] and not j in [1, 3]:
+                if i not in [1, 3] and j not in [1, 3]:
                     self.assertEqual(ofm[i, j], 0.0)
-        mtarget = np.matrix(mtarget)
         self.assertAlmostEqual(
             np.linalg.norm(ofm - mtarget), 0.0, places=4)
 
@@ -297,7 +296,6 @@ class StructureFeaturesTest(PymatgenTest):
         mtarget[33][1] = 1.4789015
         mtarget[33][3] = 1.4789015
         mtarget[33][33] = 1.4789015
-        mtarget = np.matrix(mtarget)
         self.assertAlmostEqual(
             np.linalg.norm(ofm - mtarget), 0.0, places=4)
 
@@ -360,7 +358,7 @@ class StructureFeaturesTest(PymatgenTest):
 
         # Test the feature labels
         labels = prop_fp.feature_labels()
-        self.assertEquals(3, len(labels))
+        self.assertEqual(3, len(labels))
 
         #  Test a structure with all the same type (cov should be zero)
         features = prop_fp.featurize(self.diamond)

--- a/matminer/figrecipes/plot.py
+++ b/matminer/figrecipes/plot.py
@@ -1307,7 +1307,6 @@ class PlotlyFig:
 
         return self.create_plot(fig, return_plot)
 
-
     def heatmap_df(self, data=None, cols=None, x_labels=None, x_nqs=6,
                    y_labels=None, y_nqs=4, precision=1, annotation='count',
                    annotation_color='black', colorscale=None, color_range=None,

--- a/matminer/figrecipes/tests/test_plots.py
+++ b/matminer/figrecipes/tests/test_plots.py
@@ -178,13 +178,14 @@ class PlotlyFigTest(PymatgenTest):
                           columns=['ah', 'bh', 'ch'])
         x_labels = ['low', 'high']
         y_labels = ['small', 'large']
-        hmdf_test = self.pf.heatmap_df(df, x_labels=x_labels,
-                                       y_labels=y_labels,
-                                       return_plot=True)
+        with self.assertWarns(UserWarning):
+            hmdf_test = self.pf.heatmap_df(df, x_labels=x_labels,
+                                           y_labels=y_labels,
+                                           return_plot=True)
         hmdf_true = self.fopen("template_hmdf.json")
         self.assertTrue(hmdf_test, hmdf_true)
 
-    def test_trianlge(self):
+    def test_triangle(self):
         df = pd.DataFrame(np.random.rand(50, 3), columns=list('qwe'))
         triangle_test = self.pf.triangle(df[['q', 'w', 'e']], return_plot=True)
         triangle_true = self.fopen("template_triangle.json")
@@ -192,5 +193,5 @@ class PlotlyFigTest(PymatgenTest):
 
 
 if __name__ == "__main__":
-    #refresh_json(open_plots=True)
+    # refresh_json(open_plots=True)
     unittest.main()

--- a/matminer/utils/tests/test_caching.py
+++ b/matminer/utils/tests/test_caching.py
@@ -24,27 +24,27 @@ class TestCaching(PymatgenTest):
 
         # Compute it again and make sure the cache hits
         nn_2 = get_nearest_neighbors(method, x, 0)
-        self.assertAlmostEquals(nn_1[0]['weight'], nn_2[0]['weight'])
-        self.assertEquals(1, _get_all_nearest_neighbors.cache_info().misses)
-        self.assertEquals(1, _get_all_nearest_neighbors.cache_info().hits)
+        self.assertAlmostEqual(nn_1[0]['weight'], nn_2[0]['weight'])
+        self.assertEqual(1, _get_all_nearest_neighbors.cache_info().misses)
+        self.assertEqual(1, _get_all_nearest_neighbors.cache_info().hits)
 
         # Reinstantiate the VoronoiNN class, should not cause a miss
         method = VoronoiNN()
         nn_2 = get_nearest_neighbors(method, x, 0)
-        self.assertAlmostEquals(nn_1[0]['weight'], nn_2[0]['weight'])
-        self.assertEquals(1, _get_all_nearest_neighbors.cache_info().misses)
-        self.assertEquals(2, _get_all_nearest_neighbors.cache_info().hits)
+        self.assertAlmostEqual(nn_1[0]['weight'], nn_2[0]['weight'])
+        self.assertEqual(1, _get_all_nearest_neighbors.cache_info().misses)
+        self.assertEqual(2, _get_all_nearest_neighbors.cache_info().hits)
 
         # Change the NN method, should induce a miss
         method = VoronoiNN(weight='volume')
         get_nearest_neighbors(method, x, 0)
-        self.assertEquals(2, _get_all_nearest_neighbors.cache_info().misses)
-        self.assertEquals(2, _get_all_nearest_neighbors.cache_info().hits)
+        self.assertEqual(2, _get_all_nearest_neighbors.cache_info().misses)
+        self.assertEqual(2, _get_all_nearest_neighbors.cache_info().hits)
 
         # Perturb the structure, make sure it induces a miss and
         #  a change in the NN weights
         x.perturb(0.1)
         nn_2 = get_nearest_neighbors(method, x, 0)
         self.assertNotAlmostEqual(nn_1[0]['weight'], nn_2[0]['weight'])
-        self.assertEquals(3, _get_all_nearest_neighbors.cache_info().misses)
-        self.assertEquals(2, _get_all_nearest_neighbors.cache_info().hits)
+        self.assertEqual(3, _get_all_nearest_neighbors.cache_info().misses)
+        self.assertEqual(2, _get_all_nearest_neighbors.cache_info().hits)

--- a/matminer/utils/tests/test_conversions.py
+++ b/matminer/utils/tests/test_conversions.py
@@ -56,7 +56,6 @@ class TestConversions(TestCase):
         self.assertEqual(df["structure"].tolist()[0], struct)
         self.assertEqual(df["structure"].tolist()[1], struct)
 
-
     def test_json_to_object(self):
         coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
         lattice = Lattice([[3.8401979337, 0.00, 0.00],

--- a/matminer/utils/tests/test_data.py
+++ b/matminer/utils/tests/test_data.py
@@ -16,17 +16,17 @@ class TestDemlData(TestCase):
         self.data_source = DemlData()
 
     def test_get_property(self):
-        self.assertAlmostEquals(-4.3853, self.data_source.get_elemental_property(Element("Bi"), "mus_fere"), 4)
-        self.assertEquals(59600, self.data_source.get_elemental_property(Element("Li"), "electron_affin"))
-        self.assertAlmostEquals(2372300, self.data_source.get_elemental_property(Element("He"), "first_ioniz"))
-        self.assertAlmostEquals(sum([2372300,5250500]),
-                                self.data_source.get_charge_dependent_property_from_specie(Specie("He", 2),
-                                                                                           "total_ioniz"))
-        self.assertAlmostEquals(18.6, self.data_source.get_charge_dependent_property_from_specie(Specie("V", 3),
-                                                                                                 "xtal_field_split"))
+        self.assertAlmostEqual(-4.3853, self.data_source.get_elemental_property(Element("Bi"), "mus_fere"), 4)
+        self.assertEqual(59600, self.data_source.get_elemental_property(Element("Li"), "electron_affin"))
+        self.assertAlmostEqual(2372300, self.data_source.get_elemental_property(Element("He"), "first_ioniz"))
+        self.assertAlmostEqual(sum([2372300,5250500]),
+                               self.data_source.get_charge_dependent_property_from_specie(Specie("He", 2),
+                               "total_ioniz"))
+        self.assertAlmostEqual(18.6, self.data_source.get_charge_dependent_property_from_specie(Specie("V", 3),
+                               "xtal_field_split"))
 
     def test_get_oxidation(self):
-        self.assertEquals([1], self.data_source.get_oxidation_states(Element("Li")))
+        self.assertEqual([1], self.data_source.get_oxidation_states(Element("Li")))
 
 
 class TestMagpieData(TestCase):
@@ -35,10 +35,10 @@ class TestMagpieData(TestCase):
         self.data_source = MagpieData()
 
     def test_get_property(self):
-        self.assertAlmostEquals(9.012182, self.data_source.get_elemental_property(Element("Be"), "AtomicWeight"))
+        self.assertAlmostEqual(9.012182, self.data_source.get_elemental_property(Element("Be"), "AtomicWeight"))
 
     def test_get_oxidation(self):
-        self.assertEquals([-4, 2, 4], self.data_source.get_oxidation_states(Element("C")))
+        self.assertEqual([-4, 2, 4], self.data_source.get_oxidation_states(Element("C")))
 
 
 class TestPymatgenData(TestCase):
@@ -47,13 +47,13 @@ class TestPymatgenData(TestCase):
         self.data_source = PymatgenData()
 
     def test_get_property(self):
-        self.assertAlmostEquals(9.012182, self.data_source.get_elemental_property(Element("Be"), "atomic_mass"))
-        self.assertAlmostEquals(1.26, self.data_source.get_charge_dependent_property(Element("Ac"), 3, "ionic_radii"))
+        self.assertAlmostEqual(9.012182, self.data_source.get_elemental_property(Element("Be"), "atomic_mass"))
+        self.assertAlmostEqual(1.26, self.data_source.get_charge_dependent_property(Element("Ac"), 3, "ionic_radii"))
 
     def test_get_oxidation(self):
-        self.assertEquals((3,), self.data_source.get_oxidation_states(Element("Nd")))
+        self.assertEqual((3,), self.data_source.get_oxidation_states(Element("Nd")))
         self.data_source.use_common_oxi_states = False
-        self.assertEquals((2, 3), self.data_source.get_oxidation_states(Element("Nd")))
+        self.assertEqual((2, 3), self.data_source.get_oxidation_states(Element("Nd")))
 
 
 class TestMixingEnthalpy(TestCase):
@@ -62,9 +62,9 @@ class TestMixingEnthalpy(TestCase):
         self.data = MixingEnthalpy()
 
     def test_get_data(self):
-        self.assertEquals(-27, self.data.get_mixing_enthalpy(Element('H'),
+        self.assertEqual(-27, self.data.get_mixing_enthalpy(Element('H'),
                                                              Element('Pd')))
-        self.assertEquals(-27, self.data.get_mixing_enthalpy(Element('Pd'),
+        self.assertEqual(-27, self.data.get_mixing_enthalpy(Element('Pd'),
                                                              Element('H')))
         self.assertTrue(isnan(self.data.get_mixing_enthalpy(Element('He'),
                                                             Element('H'))))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ citrination-client==4.0.1
 plotly==3.2.1
 future==0.16.0
 sympy==1.1.1
-scikit_learn==0.19.1
+scikit_learn==0.20.0
 numpy==1.15.2
 requests==2.19.1
 monty==1.0.3


### PR DESCRIPTION
## Summary

Fixed many warnings, deprecations, and hidden bugs in testing.

## TODO (if any)

There is an issue that still needs to be looked into with test_conversions.py for the featurizer tests. A warning is thrown whenever StrToComposition.featurize_dataframe is called with multiindex set to True. However this should be throwing an error instead of a warning. There is an active bug in conversions.py in the class that StrToComposition inherits from: ConversionFeaturizer. This featurizer is set to throw an error when multiindex is set to True, but there is a bug in the check where it looks for the keyword "multiiindex" instead which causes it to not fail. Instead it falls through to the BaseFeaturizer which throws a warning. I have no clue what the actual behavior of these featurizers is supposed to be when multiindex is set to True so I didn't fix it, but @utf should probably take a look.