### PR TITLE
Larger default for chunksize

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -147,7 +147,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
     @property
     def chunksize(self):
-        return self._chunksize if hasattr(self, '_chunksize') else 1
+        return self._chunksize if hasattr(self, '_chunksize') else None
 
     def fit(self, X, y=None, **fit_kwargs):
         """Update the parameters of this featurizer based on available data

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -82,7 +82,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     that are set by fitting should be stored as class attributes that end with
     an underscore. (This follows the pattern used by ScikitLearn).
 
-    Another implementation to consider is whether it is worth making any utility
+    Another option to consider is whether it is worth making any utility
     operations for your featurizer. `featurize` must return a list of features,
     but this may not be the most natural representation for your features (e.g.,
     a `dict` could be better). Making a separate function for computing features
@@ -101,12 +101,14 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     to the tasks can be reduced. Note that there is only an advantage to using
     chunksize when the time taken to pass the data from `map` to the function
     call is within several orders of magnitude to that of the function call
-    itself. For computationally expensive featurizers, the default
-    chunksize of 1 will be the most efficient. However, for more lightweight
-    featurizers, it is recommended that the implementor trial a range of
-    chunksize values to find the optimum. As a general rule of thumb, if the
-    featurize function takes 0.1 seconds or less, a chunksize of around 30 will
-    perform best. For longer featurize times, a chunksize of 1 should be used.
+    itself. By default, we allow the Python multiprocessing library to determine
+    the chunk size automatically based on the size of the list being featurized.
+    You may want to specify a small chunk size for computationally-expensive
+    featurizers, which will enable better distribution of taks across threads.
+    In contrast, for more lightweight featurizers, it is recommended that 
+    the implementor trial a range of chunksize values to find the optimum. 
+    As a general rule of thumb, if the featurize function takes 0.1 seconds or 
+    less, a chunksize of around 30 will perform best.
 
     ## Documenting a BaseFeaturizer
 

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -105,9 +105,9 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     the chunk size automatically based on the size of the list being featurized.
     You may want to specify a small chunk size for computationally-expensive
     featurizers, which will enable better distribution of taks across threads.
-    In contrast, for more lightweight featurizers, it is recommended that 
-    the implementor trial a range of chunksize values to find the optimum. 
-    As a general rule of thumb, if the featurize function takes 0.1 seconds or 
+    In contrast, for more lightweight featurizers, it is recommended that
+    the implementor trial a range of chunksize values to find the optimum.
+    As a general rule of thumb, if the featurize function takes 0.1 seconds or
     less, a chunksize of around 30 will perform best.
 
     ## Documenting a BaseFeaturizer


### PR DESCRIPTION
I think the current default value for `chunksize` used in multiprocessing is too small. 

When upgrading to the latest version of matminer, my performance dropped by ~100x for parallel featurization (not entirely sure because it too so long I killed the process). I traced it to the choice of `chunksize` default, and after switching to using a `chunksize` of `None` (which causes matminer to rely on the default for `multiprocessing`) I was back to having acceptable performance. 

The featurizerizers I was using are pretty representative of the others in matminer, so I suspect the default for `multiprocessing` is likely a good choice for the default for matminer.

## Summary

This commit changes the code to rely on the default for multiprocessing rather than 1 for the chunksize. 

## TODO (if any)

None