### PR TITLE
Fix MDF unit tests

### DIFF
--- a/matminer/data_retrieval/retrieve_MDF.py
+++ b/matminer/data_retrieval/retrieve_MDF.py
@@ -87,7 +87,6 @@ class MDFDataRetrieval(BaseDataRetrieval):
         results = self.forge.aggregate()
         return make_dataframe(results, unwind_arrays=unwind_arrays)
 
-
     def get_data(self, squery, unwind_arrays=True, **kwargs):
         """
         Gets a dataframe from the MDF API from an explicit string
@@ -105,7 +104,6 @@ class MDFDataRetrieval(BaseDataRetrieval):
         """
         results = self.forge.aggregate(q=squery, **kwargs)
         return make_dataframe(results, unwind_arrays=unwind_arrays)
-
 
 
 #TODO: could add parallel functionality, but doesn't seem to be too slow

--- a/matminer/data_retrieval/tests/test_retrieve_MDF.py
+++ b/matminer/data_retrieval/tests/test_retrieve_MDF.py
@@ -18,12 +18,10 @@ class MDFDataRetrievalTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.mdf_dr = MDFDataRetrieval(anonymous=True)
-        # cls.oqmd_version = cls.mdf_dr.forge.get_dataset_version('oqmd')
 
-    @unittest.expectedFailure
     def test_get_dataframe(self):
         results = self.mdf_dr.get_dataframe({
-            "source_names": ['oqmd_v%d' % self.oqmd_version],
+            "source_names": ['oqmd'],
             "elements": ["Ag", "Be", "V"]},
             unwind_arrays=False)
         for elts in results['material.elements']:
@@ -31,13 +29,12 @@ class MDFDataRetrievalTest(unittest.TestCase):
             self.assertTrue("Ag" in elts)
             self.assertTrue("V" in elts)
 
-    @unittest.expectedFailure
     def test_get_dataframe_by_query(self):
-        qstring = "(mdf.source_name:oqmd_v{0}) AND "\
+        qstring = "(mdf.source_name:oqmd) AND "\
                   "(material.elements:Si AND material.elements:V AND "\
-                  "oqmd_v{0}.band_gap.value:[0.5 TO *])".format(self.oqmd_version)
+                  "oqmd.band_gap.value:[0.5 TO *])"
         mdf_df = self.mdf_dr.get_data(qstring, unwind_arrays=False)
-        self.assertTrue((mdf_df['oqmd_v%d.band_gap.value'%self.oqmd_version] > 0.5).all())
+        self.assertTrue((mdf_df['oqmd.band_gap.value'] > 0.5).all())
         for elts in mdf_df['material.elements']:
             self.assertTrue("Si" in elts)
             self.assertTrue("V" in elts)


### PR DESCRIPTION
Fixes #325

The new MDF search index is online. The new version also does require using the version of a dataset in the query string.

I'll go update the matminer_examples tests accordingly.

## Summary

- MDF tests are no longer expected failures
- Removes need to access dataset version in unit tests

## TODO (if any)

None