### PR TITLE
HOTFIX: fix setup script to include dataset metadata file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
         author_email='anubhavster@gmail.com',
         license='modified BSD',
         packages=find_packages(),
-        package_data={'matminer.datasets': ['*.csv'],
+        package_data={'matminer.datasets': ['*.json'],
                       'matminer.featurizers': ["*.yaml"],
                       'matminer.utils.data_files': ['*.csv', '*.tsv', '*.json', 'magpie_elementdata/*.table']},
         zip_safe=False,


### PR DESCRIPTION
## Summary

This is a fix to the setup script which previously was not set to include the dataset_metadata.json file necessary for loading in datasets from the datasets module. This error flew under my radar in testing as my tests ran code directly from the development directory rather than setting up an environment that mirrors the deployed package.

This issue perhaps highlights further need to enhance the project CircleCI tests to install the package and run code based on the user facing install rather than code and files copied directly from the GitHub repo.

@computron Given that the matminer dataset interface is effectively broken in 0.4.4 a roleback of some sort may be wise for that version.