### PR TITLE
Update to include CITRINATION_API_KEY

### DIFF
--- a/matminer/data_retrieval/retrieve_Citrine.py
+++ b/matminer/data_retrieval/retrieve_Citrine.py
@@ -40,7 +40,13 @@ class CitrineDataRetrieval(BaseDataRetrieval):
             api_key: (str) Your Citrine API key, or None if
                 you've set the CITRINE_KEY environment variable
         """
-        api_key = api_key if api_key else os.environ["CITRINE_KEY"]
+        if api_key:
+            api_key = api_key
+        elif os.environ["CITRINATION_API_KEY"]:
+            api_key = os.environ["CITRINATION_API_KEY"]
+        else:
+            api_key = os.environ["CITRINE_KEY"]
+            
         self.client = CitrinationClient(api_key, "https://citrination.com")
 
     def api_link(self):


### PR DESCRIPTION
## Summary

Most tutorials and documentation for Citrination ask users to store their API key under CITRINATION_API_KEY as opposed to CITRINE_KEY. Adding a conditional tree to accept either should serve more users.

* Added conditional logic to look in os.environ for CITRINATION_API_KEY as well as CITRINE_KEY