### PR TITLE
Prepend names of data sources to ElementProperty entries

### DIFF
--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -49,6 +49,20 @@ class ElementProperty(BaseFeaturizer):
 
     To initialize quickly, use the from_preset() method.
 
+    Features: Based on the statistics of the data_source chosen, computed
+    by element stoichiometry. The format generally is:
+
+    "{data source} {statistic} {property}"
+
+    For example:
+
+    "PymetgenData range X"  # Range of electronegativity from Pymatgen data
+
+    For a list of all statistics, see the PropertyStats documentation; for a
+    list of all attributes available for a given data_source, see the
+    documentation for the data sources (e.g., PymatgenData, MagpieData,
+    MatscholarElementData, etc.).
+
     Args:
         data_source (AbstractData or str): source from which to retrieve
             element property data (or use str for preset: "pymatgen",
@@ -73,6 +87,8 @@ class ElementProperty(BaseFeaturizer):
 
         self.features = features
         self.stats = stats
+        # Initialize stats computer
+        self.pstats = PropertyStats()
 
     @classmethod
     def from_preset(cls, preset_name):
@@ -140,9 +156,6 @@ class ElementProperty(BaseFeaturizer):
 
         all_attributes = []
 
-        # Initialize stats computer
-        pstats = PropertyStats()
-
         # Get the element names and fractions
         elements, fractions = zip(*comp.element_composition.items())
 
@@ -150,7 +163,7 @@ class ElementProperty(BaseFeaturizer):
             elem_data = [self.data_source.get_elemental_property(e, attr) for e in elements]
 
             for stat in self.stats:
-                all_attributes.append(pstats.calc_stat(elem_data, stat, fractions))
+                all_attributes.append(self.pstats.calc_stat(elem_data, stat, fractions))
 
         return all_attributes
 
@@ -198,9 +211,22 @@ class CationProperty(ElementProperty):
     """
     Features based on properties of cations in a material
 
-    Requires that oxidation states have already been determined
+    Requires that oxidation states have already been determined. Property
+    statistics weighted by composition.
 
-    Computes composition-weighted statistics of different elemental properties
+    Features: Based on the statistics of the data_source chosen, computed
+    by element stoichiometry. The format generally is:
+
+    "{data source} {statistic} {property}"
+
+    For example:
+
+    "DemlData range magn_moment" # Range of magnetic moment via Deml et al. data
+
+    For a list of all statistics, see the PropertyStats documentation; for a
+    list of all attributes available for a given data_source, see the
+    documentation for the data sources (e.g., PymatgenData, MagpieData,
+    MatscholarElementData, etc.).
     """
 
     @classmethod

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -207,19 +207,15 @@ class CationProperty(ElementProperty):
     def from_preset(cls, preset_name):
         if preset_name == "deml":
             data_source = "deml"
-            features = ["total_ioniz", "xtal_field_split", "magn_moment", "so_coupling", "sat_magn"]
+            features = ["total_ioniz", "xtal_field_split", "magn_moment",
+                        "so_coupling", "sat_magn"]
             stats = ["minimum", "maximum", "range", "mean", "std_dev"]
         else:
-            raise ValueError('Preset "%s" not found'%preset_name)
+            raise ValueError('Preset "%s" not found' % preset_name)
         return cls(data_source, features, stats)
 
     def feature_labels(self):
-        labels = []
-        for attr in self.features:
-            for stat in self.stats:
-                labels.append("%s %s of cations"%(stat, attr))
-
-        return labels
+        return [f + " of cations" for f in super().feature_labels()]
 
     def featurize(self, comp):
         # Check if oxidation states are present

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -157,8 +157,9 @@ class ElementProperty(BaseFeaturizer):
     def feature_labels(self):
         labels = []
         for attr in self.features:
+            src = self.data_source.__class__.__name__
             for stat in self.stats:
-                labels.append("%s %s" % (stat, attr))
+                labels.append("{} {} {}".format(src, stat, attr))
         return labels
 
     def citations(self):

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -39,12 +39,12 @@ class CompositionFeaturesTest(PymatgenTest):
 
     def test_elem(self):
         df_elem = ElementProperty.from_preset("magpie").featurize_dataframe(self.df, col_id="composition")
-        self.assertAlmostEqual(df_elem["minimum Number"][0], 8)
-        self.assertAlmostEqual(df_elem["maximum Number"][0], 26)
-        self.assertAlmostEqual(df_elem["range Number"][0], 18)
-        self.assertAlmostEqual(df_elem["mean Number"][0], 15.2)
-        self.assertAlmostEqual(df_elem["avg_dev Number"][0], 8.64)
-        self.assertAlmostEqual(df_elem["mode Number"][0], 8)
+        self.assertAlmostEqual(df_elem["MagpieData minimum Number"][0], 8)
+        self.assertAlmostEqual(df_elem["MagpieData maximum Number"][0], 26)
+        self.assertAlmostEqual(df_elem["MagpieData range Number"][0], 18)
+        self.assertAlmostEqual(df_elem["MagpieData mean Number"][0], 15.2)
+        self.assertAlmostEqual(df_elem["MagpieData avg_dev Number"][0], 8.64)
+        self.assertAlmostEqual(df_elem["MagpieData mode Number"][0], 8)
 
     def test_elem_deml(self):
         df_elem_deml = ElementProperty.from_preset("deml").featurize_dataframe(self.df, col_id="composition")
@@ -57,11 +57,11 @@ class CompositionFeaturesTest(PymatgenTest):
     def test_cation_properties(self):
         featurizer = CationProperty.from_preset("deml")
         features = dict(zip(featurizer.feature_labels(), featurizer.featurize(self.df["composition"][1])))
-        self.assertAlmostEqual(features["MagpieData minimum magn_moment of cations"], 5.48)
-        self.assertAlmostEqual(features["MagpieData maximum magn_moment of cations"], 5.48)
-        self.assertAlmostEqual(features["MagpieData range magn_moment of cations"], 0)
-        self.assertAlmostEqual(features["MagpieData mean magn_moment of cations"], 5.48)
-        self.assertAlmostEqual(features["MagpieData std_dev magn_moment of cations"], 0)
+        self.assertAlmostEqual(features["DemlData minimum magn_moment of cations"], 5.48)
+        self.assertAlmostEqual(features["DemlData maximum magn_moment of cations"], 5.48)
+        self.assertAlmostEqual(features["DemlData range magn_moment of cations"], 0)
+        self.assertAlmostEqual(features["DemlData mean magn_moment of cations"], 5.48)
+        self.assertAlmostEqual(features["DemlData std_dev magn_moment of cations"], 0)
 
     def test_elem_matminer(self):
         df_elem = ElementProperty.from_preset("matminer").featurize_dataframe(self.df, col_id="composition")
@@ -141,11 +141,11 @@ class CompositionFeaturesTest(PymatgenTest):
                                        stats=["minimum", "maximum", "range", "mean", "std_dev"],
                                        data_source="deml")\
             .featurize_dataframe(self.df, col_id="composition")
-        self.assertAlmostEqual(df_fere_corr["minimum FERE correction"][0], -0.15213431610903)
-        self.assertAlmostEqual(df_fere_corr["maximum FERE correction"][0], 0.23)
-        self.assertAlmostEqual(df_fere_corr["range FERE correction"][0], 0.382134316)
-        self.assertAlmostEqual(df_fere_corr["mean FERE correction"][0], 0.077146274)
-        self.assertAlmostEqual(df_fere_corr["std_dev FERE correction"][0], 0.270209766)
+        self.assertAlmostEqual(df_fere_corr["DemlData minimum FERE correction"][0], -0.15213431610903)
+        self.assertAlmostEqual(df_fere_corr["DemlData maximum FERE correction"][0], 0.23)
+        self.assertAlmostEqual(df_fere_corr["DemlData range FERE correction"][0], 0.382134316)
+        self.assertAlmostEqual(df_fere_corr["DemlData mean FERE correction"][0], 0.077146274)
+        self.assertAlmostEqual(df_fere_corr["DemlData std_dev FERE correction"][0], 0.270209766)
 
     def test_atomic_orbitals(self):
         df_atomic_orbitals = AtomicOrbitals().featurize_dataframe(self.df, col_id="composition")

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -48,38 +48,38 @@ class CompositionFeaturesTest(PymatgenTest):
 
     def test_elem_deml(self):
         df_elem_deml = ElementProperty.from_preset("deml").featurize_dataframe(self.df, col_id="composition")
-        self.assertAlmostEqual(df_elem_deml["minimum atom_num"][0], 8)
-        self.assertAlmostEqual(df_elem_deml["maximum atom_num"][0], 26)
-        self.assertAlmostEqual(df_elem_deml["range atom_num"][0], 18)
-        self.assertAlmostEqual(df_elem_deml["mean atom_num"][0], 15.2)
-        self.assertAlmostEqual(df_elem_deml["std_dev atom_num"][0], 12.7279, 4)
+        self.assertAlmostEqual(df_elem_deml["DemlData minimum atom_num"][0], 8)
+        self.assertAlmostEqual(df_elem_deml["DemlData maximum atom_num"][0], 26)
+        self.assertAlmostEqual(df_elem_deml["DemlData range atom_num"][0], 18)
+        self.assertAlmostEqual(df_elem_deml["DemlData mean atom_num"][0], 15.2)
+        self.assertAlmostEqual(df_elem_deml["DemlData std_dev atom_num"][0], 12.7279, 4)
 
     def test_cation_properties(self):
         featurizer = CationProperty.from_preset("deml")
         features = dict(zip(featurizer.feature_labels(), featurizer.featurize(self.df["composition"][1])))
-        self.assertAlmostEqual(features["minimum magn_moment of cations"], 5.48)
-        self.assertAlmostEqual(features["maximum magn_moment of cations"], 5.48)
-        self.assertAlmostEqual(features["range magn_moment of cations"], 0)
-        self.assertAlmostEqual(features["mean magn_moment of cations"], 5.48)
-        self.assertAlmostEqual(features["std_dev magn_moment of cations"], 0)
+        self.assertAlmostEqual(features["MagpieData minimum magn_moment of cations"], 5.48)
+        self.assertAlmostEqual(features["MagpieData maximum magn_moment of cations"], 5.48)
+        self.assertAlmostEqual(features["MagpieData range magn_moment of cations"], 0)
+        self.assertAlmostEqual(features["MagpieData mean magn_moment of cations"], 5.48)
+        self.assertAlmostEqual(features["MagpieData std_dev magn_moment of cations"], 0)
 
     def test_elem_matminer(self):
         df_elem = ElementProperty.from_preset("matminer").featurize_dataframe(self.df, col_id="composition")
-        self.assertAlmostEqual(df_elem["minimum melting_point"][0], 54.8, 1)
-        self.assertTrue(math.isnan(df_elem["maximum bulk_modulus"][0]))
-        self.assertAlmostEqual(df_elem["range X"][0], 1.61, 1)
-        self.assertAlmostEqual(df_elem["mean X"][0], 2.796, 1)
-        self.assertAlmostEqual(df_elem["maximum block"][0], 3, 1)
+        self.assertAlmostEqual(df_elem["PymatgenData minimum melting_point"][0], 54.8, 1)
+        self.assertTrue(math.isnan(df_elem["PymatgenData maximum bulk_modulus"][0]))
+        self.assertAlmostEqual(df_elem["PymatgenData range X"][0], 1.61, 1)
+        self.assertAlmostEqual(df_elem["PymatgenData mean X"][0], 2.796, 1)
+        self.assertAlmostEqual(df_elem["PymatgenData maximum block"][0], 3, 1)
 
     def test_elem_matscholar_el(self):
         df_elem = ElementProperty.from_preset("matscholar_el").featurize_dataframe(self.df, col_id="composition")
-        self.assertAlmostEqual(df_elem["range matscholar_el_149"].iloc[0],
+        self.assertAlmostEqual(df_elem["MatscholarElementData range embedding 149"].iloc[0],
                                0.06827970966696739)
-        self.assertAlmostEqual(df_elem["range matscholar_el_149"].iloc[1],
+        self.assertAlmostEqual(df_elem["MatscholarElementData range embedding 149"].iloc[1],
                                0.06827970966696739)
-        self.assertAlmostEqual(df_elem["mean matscholar_el_18"].iloc[0],
+        self.assertAlmostEqual(df_elem["MatscholarElementData mean embedding 18"].iloc[0],
                                -0.020534400502219795)
-        self.assertAlmostEqual(df_elem["mean matscholar_el_18"].iloc[1],
+        self.assertAlmostEqual(df_elem["MatscholarElementData mean embedding 18"].iloc[1],
                                -0.02483355056028813)
 
 

--- a/matminer/utils/data.py
+++ b/matminer/utils/data.py
@@ -305,7 +305,7 @@ class MatscholarElementData(AbstractData):
                              "data_files/matscholar_els.json")
         with open(dfile, "r") as fp:
             embeddings = json.load(fp)
-        self.prop_names = ["matscholar_el_{}".format(i) for i in range(1, 201)]
+        self.prop_names = ["embedding {}".format(i) for i in range(1, 201)]
         all_element_data = {}
         for el, embedding in embeddings.items():
             all_element_data[el] = dict(zip(self.prop_names, embedding))


### PR DESCRIPTION
## Summary

Some ElementProperty presets have overlapping feature names (e.g., deml preset and matminer preset on boiling_point) which will cause featurizing with ElementProperty.from_preset("deml") and ElementProperty.from_preset("matminer") in succession to fail. 

Also, featurizing with multiple ElementProperty presets will cause potential confusion even if there is not a name conflict. For example, if you featurize with the matminer data source and then the magpie data source, you'll have "minimum X" and "minimum Electronegativity". Which feature comes from which data source?

Yes, you could just do `featurizer.feature_labels()` to find out which data source it came from, but this is just an extra step. We can have it so any user will be able to tell from the feature names.

This PR prepends the class names of the `data_source` to all statistics computed with that ElementProperty object. Here are some examples of the changes:

Before:
```
'mean matscholar_el_147'     # Matscholar embeddings
'range Electronegativity'    # Magpie
'range X'                    # matminer
'range electronegativity'    # Deml
```

After:
```
'MatscholarElementData mean embedding 147'
'MagpieData range Electronegativity'
'PymatgenData range X'
'DemlData range electronegativity'
```

### Classes affected
ElementProperty
CationProperty
