### PR TITLE
Resolve bugs in IUCrBondValenceData

### DIFF
--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -1689,7 +1689,7 @@ class LocalPropertyDifference(BaseFeaturizer):
             Voronoi tessellation
 
     References:
-         `Ward et al. _PRB_ 2017 <http://link.aps.org/doi/10.1103/PhysRevB.96.014107>`_
+         `Ward et al. _PRB_ 2017 <http://link.aps.org/doi/10.1103/PhysRevB.96.024104>`_
     """
 
     def __init__(self, data_source=MagpieData(), weight='area',

--- a/matminer/utils/data.py
+++ b/matminer/utils/data.py
@@ -436,6 +436,8 @@ class IUCrBondValenceData:
         Returns:
             bond_val_list: dataframe of bond valence parameters
         """
+
+        bv_data = self.params
         bond_val_list = self.params.loc[(bv_data['Atom1'] == str(cation)) \
                                 & (bv_data['Atom1_valence'] == cat_val) \
                                 & (bv_data['Atom2'] == str(anion)) \

--- a/matminer/utils/tests/test_data.py
+++ b/matminer/utils/tests/test_data.py
@@ -5,7 +5,7 @@ from math import isnan
 from pymatgen.core.periodic_table import Specie
 
 from matminer.utils.data import DemlData, MagpieData, PymatgenData, \
-    MixingEnthalpy, MatscholarElementData, MEGNetElementData
+    MixingEnthalpy, MatscholarElementData, MEGNetElementData, IUCrBondValenceData
 from pymatgen import Element
 
 
@@ -99,6 +99,14 @@ class TestMixingEnthalpy(TestCase):
                                                              Element('H')))
         self.assertTrue(isnan(self.data.get_mixing_enthalpy(Element('He'),
                                                             Element('H'))))
+class TestIUCrBondValenceData(TestCase):
+
+    def setUp(self):
+        self.data = IUCrBondValenceData()
+
+    def test_get_data(self):
+        nacl = self.data.get_bv_params("Na", "Cl", 1, -1)
+        self.assertAlmostEqual(nacl['Ro'], 2.15)
 
 if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
         package_data={
             'matminer.datasets': ['*.json'],
             'matminer.featurizers': ["*.yaml"],
-            'matminer.utils.data_files': ['*.csv', '*.tsv', '*.json',
+            'matminer.utils.data_files': ['*.cif', '*.csv', '*.tsv', '*.json',
                                           'magpie_elementdata/*.table',
                                           'jarvis/*.json']},
         zip_safe=False,


### PR DESCRIPTION
## Summary

* `IUCrBondValenceData` is very useful but missed a line for execution. A test is added to ensure that the patch resolves this problem.
* `setup.py` is modified to include bvparam2016.cif in the package.
* URL for PRB 2017 is fixed.
