### PR TITLE
fix precheck for composition objects with oxidation states

### DIFF
--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -1123,7 +1123,8 @@ class Miedema(BaseFeaturizer):
         Returns:
             (bool): If True, s passed the precheck; otherwise, it failed.
         """
-        return all([e in self.element_list for e in c.elements])
+        return all([e in self.element_list
+                    for e in c.element_composition.elements])
 
     def deltaH_chem(self, elements, fracs, struct):
         """
@@ -1450,7 +1451,8 @@ class YangSolidSolution(BaseFeaturizer):
         Returns:
             (bool): If True, s passed the precheck; otherwise, it failed.
         """
-        return all([e in self.dhf_mix.valid_element_list for e in c.elements])
+        return all([e in self.dhf_mix.valid_element_list
+                    for e in c.element_composition.elements])
 
     def featurize(self, comp):
         return [self.compute_omega(comp), self.compute_delta(comp)]

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -198,14 +198,14 @@ class CompositionFeaturesTest(PymatgenTest):
                                            Composition("Mg10Cu50Ca40"),
                                            Composition("Fe2O3")]})
         miedema = Miedema(struct_types='all')
-        self.assertFalse(miedema.precheck(df["composition"].iloc[0]))
+        self.assertTrue(miedema.precheck(df["composition"].iloc[0]))
         self.assertFalse(miedema.precheck(df["composition"].iloc[-1]))
         self.assertAlmostEqual(miedema.precheck_dataframe(df, "composition"), 2 / 3)
 
         # test precheck for oxidation-state decorated compositions
         df = CompositionToOxidComposition(return_original_on_error=True).\
             featurize_dataframe(df, 'composition')
-        self.assertFalse(miedema.precheck(df["composition_oxid"].iloc[0]))
+        self.assertTrue(miedema.precheck(df["composition_oxid"].iloc[0]))
         self.assertFalse(miedema.precheck(df["composition_oxid"].iloc[-1]))
         self.assertAlmostEqual(miedema.precheck_dataframe(df, "composition_oxid"), 2 / 3)
 

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -17,6 +17,7 @@ from matminer.featurizers.composition import Stoichiometry, ElementProperty, \
     CohesiveEnergy, \
     BandCenter, Miedema, CationProperty, OxidationStates, AtomicOrbitals, \
     YangSolidSolution, AtomicPackingEfficiency
+from matminer.featurizers.conversions import CompositionToOxidComposition
 
 
 class CompositionFeaturesTest(PymatgenTest):
@@ -197,8 +198,17 @@ class CompositionFeaturesTest(PymatgenTest):
                                            Composition("Mg10Cu50Ca40"),
                                            Composition("Fe2O3")]})
         miedema = Miedema(struct_types='all')
+        self.assertFalse(miedema.precheck(df["composition"].iloc[0]))
         self.assertFalse(miedema.precheck(df["composition"].iloc[-1]))
         self.assertAlmostEqual(miedema.precheck_dataframe(df, "composition"), 2 / 3)
+
+        # test precheck for oxidation-state decorated compositions
+        df = CompositionToOxidComposition(return_original_on_error=True).\
+            featurize_dataframe(df, 'composition')
+        self.assertFalse(miedema.precheck(df["composition_oxid"].iloc[0]))
+        self.assertFalse(miedema.precheck(df["composition_oxid"].iloc[-1]))
+        self.assertAlmostEqual(miedema.precheck_dataframe(df, "composition_oxid"), 2 / 3)
+
         mfps = miedema.featurize_dataframe(df, col_id="composition")
         self.assertAlmostEqual(mfps['Miedema_deltaH_inter'][0], -0.003445022152)
         self.assertAlmostEqual(mfps['Miedema_deltaH_amor'][0], 0.0707658836300)
@@ -211,6 +221,13 @@ class CompositionFeaturesTest(PymatgenTest):
         self.assertAlmostEqual(math.isnan(mfps['Miedema_deltaH_inter'][2]), True)
         self.assertAlmostEqual(math.isnan(mfps['Miedema_deltaH_amor'][2]), True)
         self.assertAlmostEqual(math.isnan(mfps['Miedema_deltaH_ss_min'][2]), True)
+
+        # make sure featurization works equally for compositions with or without
+        # oxidation states
+        mfps = miedema.featurize_dataframe(df, col_id="composition_oxid")
+        self.assertAlmostEqual(mfps['Miedema_deltaH_inter'][0], -0.003445022152)
+        self.assertAlmostEqual(mfps['Miedema_deltaH_amor'][0], 0.0707658836300)
+        self.assertAlmostEqual(mfps['Miedema_deltaH_ss_min'][0], 0.03663599755)
 
     def test_miedema_ss(self):
         df = pd.DataFrame({"composition": [Composition("TiZr"),
@@ -246,8 +263,14 @@ class CompositionFeaturesTest(PymatgenTest):
         feat = YangSolidSolution()
 
         df = pd.DataFrame({"composition": comps})
-        self.assertFalse(feat.precheck(comps[-1]))
+        self.assertFalse(feat.precheck(df["composition"].iloc[-1]))
         self.assertAlmostEqual(feat.precheck_dataframe(df, "composition"), 0.8, places=2)
+
+        # test precheck for oxidation-state decorated compositions
+        df = CompositionToOxidComposition(return_original_on_error=True). \
+            featurize_dataframe(df, 'composition')
+        self.assertFalse(feat.precheck(df["composition_oxid"].iloc[-1]))
+        self.assertAlmostEqual(feat.precheck_dataframe(df, "composition_oxid"), 0.8, places=2)
 
         feat.set_n_jobs(1)
         features = feat.featurize_many(comps)


### PR DESCRIPTION
## Summary

The current `precheck` for Miedema and YangSolidSolution Featurizers will naturally fail for composition objects with oxidation states which causes a problem in automatminer featurization. This PR fixes this issue. 

Tests are also added to make sure `precheck` + `featurization` work equally for compositions with or without oxidation states. 