### PR TITLE
Update Google Groups references to Discourse 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 Please submit help issues to:
-https://groups.google.com/forum/#!forum/matminer
+https://hackingmaterials.discourse.group/c/matminer/automatminer
 
 The Github issues is no longer used except for internal development purposes.
 
-If you are unable to use the Google Group, you may submit an issue here, but you must **clearly** state the reason you are unable to use the Google Group in your ticket. Otherwise, your issue will be **closed** without response.
+If you are unable to use the Discourse forum, you may submit an issue here, but you must **clearly** state the reason you are unable to use the Discourse forum in your ticket. Otherwise, your issue will be **closed** without response.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We love your input! We want to make contributing to matminer as easy and transpa
 * Becoming a maintainer
 
 ## Reporting bugs, getting help, and discussion
-At any time, feel free to start a thread on our [Google Group](https://groups.google.com/forum/#!forum/matminer).
+At any time, feel free to start a thread on our [Discourse forum](https://hackingmaterials.discourse.group/c/matminer).
 
 If you are making a bug report, incorporate as many elements of the following as possible to ensure a timely response and avoid the need for followups:
 * A quick summary and/or background
@@ -35,10 +35,10 @@ We have a few tips for writing good PRs that are accepted into the main repo:
 * Your code should have (4) spaces instead of tabs.
 * If needed, update the documentation.
 * **Write tests** for new features! Good tests are 100%, absolutely necessary for good code. We use the python `unittest` framework -- see some of the other tests in this repo for examples, or review the [Hitchhiker's guide to python](https://docs.python-guide.org/writing/tests/) for some good resources on writing good tests.
-* Understand your contributions will fall under the same license as this repo. 
+* Understand your contributions will fall under the same license as this repo.
 
-When you submit your PR, our CI service will automatically run your tests. 
+When you submit your PR, our CI service will automatically run your tests.
 We welcome good discussion on the best ways to write your code, and the comments on your PR are an excellent area for discussion.
 
 #### References
-This document was adapted from the open-source contribution guidelines for Facebook's Draft, as well as briandk's [contribution template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62). 
+This document was adapted from the open-source contribution guidelines for Facebook's Draft, as well as briandk's [contribution template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62).

--- a/docs_rst/index.rst
+++ b/docs_rst/index.rst
@@ -198,7 +198,7 @@ Want to see something added or changed? Here's a few ways you can!
 * Let us know about areas of the code that are difficult to understand or use.
 * Contribute code! Fork our `Github repo <https://github.com/hackingmaterials/matminer>`_ and make a pull request.
 
-Submit all questions and contact to the `Google group <https://groups.google.com/forum/#!forum/matminer>`_
+Submit all questions and contact to the `Discourse forum <https://hackingmaterials.discourse.group/c/matminer>`_
 
 A comprehensive guide to contributions can be found `here. <https://github.com/hackingmaterials/matminer/blob/master/CONTRIBUTING.md>`_
 

--- a/docs_rst/installation.rst
+++ b/docs_rst/installation.rst
@@ -54,5 +54,5 @@ Tips
 * If you have trouble with the installation of a component library (sympy, pymatgen, mdf-forge, etc.), you can try to run ``pip install <<component>>`` or (if you are using `Anaconda <https://www.anaconda.com/distribution/>`_) ``conda install <<component>>`` first, and then re-try the installation.
 
     - For example, installing pymatgen on a Windows platform is easiest with Anaconda via ``conda install -c conda-forge pymatgen``.
-    
-* If you still have trouble, open up a a ticket on our `forum <https://groups.google.com/forum/#!forum/matminer>`_  describing your problem in full (including your system specifications, Python version information, and input/output log). There is a good likelihood that someone else is running into the same issue, and by posting it on the forum we can help make the documentation clearer and smoother.
+
+* If you still have trouble, open up a a ticket on our `forum <https://hackingmaterials.discourse.group/c/matminer>`_  describing your problem in full (including your system specifications, Python version information, and input/output log). There is a good likelihood that someone else is running into the same issue, and by posting it on the forum we can help make the documentation clearer and smoother.


### PR DESCRIPTION
The Matminer support forum is moving from Google Groups to Discourse (https://hackingmaterials.discourse.group/c/matminer). I've updated all references to Google Groups to point to the new forum.

Once merged, the docs should be regenerated to reflect the updates.