### PR TITLE
Moved the SOAP featurizer from matminer.featurizers.structure to matm…

### DIFF
--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -2288,10 +2288,10 @@ class SOAP(BaseFeaturizer):
         self.length = self.soap.get_number_of_features()
         return self
 
-    def featurize(self, s):
+    def featurize(self, struct, idx):
         self._check_fitted()
-        s_ase = self.adaptor.get_atoms(s)
-        return self.soap.create(s_ase).tolist()[0]
+        s_ase = self.adaptor.get_atoms(struct)
+        return self.soap.create(s_ase, positions=[idx]).tolist()[0]
 
     def feature_labels(self):
         self._check_fitted()

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -2,6 +2,9 @@ from __future__ import division
 
 import copy
 from functools import lru_cache
+from monty.dev import requires
+from pymatgen.io.ase import AseAtomsAdaptor
+from sklearn.exceptions import NotFittedError
 
 from matminer.featurizers.utils.grdf import Gaussian, Histogram
 from matminer.utils.caching import get_nearest_neighbors
@@ -49,6 +52,13 @@ from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies \
 
 from matminer.featurizers.utils.stats import PropertyStats
 from sklearn.utils.validation import check_is_fitted
+
+# SOAPFeaturizer
+try:
+    import dscribe
+    from dscribe.descriptors import SOAP as SOAP_dscribe
+except ImportError:
+    dscribe, SOAP_dscribe = None, None
 
 cn_motif_op_params = {}
 with open(os.path.join(os.path.dirname(
@@ -2151,3 +2161,190 @@ class AverageBondAngle(BaseFeaturizer):
 
     def implementors(self):
         return ['Logan Ward', 'Aik Rui Tan']
+
+
+class SOAP(BaseFeaturizer):
+    """
+    Smooth overlap of atomic positions (interface via DScribe).
+
+    Class for generating a partial power spectrum from Smooth Overlap of Atomic
+    Orbitals (SOAP). This implementation uses real (tesseral) spherical
+    harmonics as the angular basis set and provides two orthonormalized
+    alternatives for the radial basis functions: spherical primitive gaussian
+    type orbitals ("gto") or the polynomial basis set ("polynomial"). By
+    default the faster gto-basis is used. Please see the DScribe SOAP
+    documentation for more details.
+
+    Note that SOAP is only featurized for elements identified by "fit" (see
+    following), thus "fit" must be called before "featurize", or else an error
+    will be raised.
+
+    Based originally on the following publications:
+
+    "On representing chemical environments, Albert P. Bartók, Risi
+        Kondor, and Gábor Csányi, Phys. Rev. B 87, 184115, (2013),
+        https://doi.org/10.1103/PhysRevB.87.184115
+
+    "Comparing molecules and solids across structural and alchemical
+        space", Sandip De, Albert P. Bartók, Gábor Csányi and Michele Ceriotti,
+        Phys.  Chem. Chem. Phys. 18, 13754 (2016),
+        https://doi.org/10.1039/c6cp00415f
+
+    Implementation (and some documentation) originally based on DScribe:
+    https://github.com/SINGROUP/dscribe.
+
+    "DScribe: Library of descriptors for machine learning in materials science",
+        Himanen, L., J{\"a}ger, M. O.J., Morooka, E. V., Federici
+        Canova, F., Ranawat, Y. S., Gao, D. Z., Rinke, P. and Foster, A. S.
+        Computer Physics Communications, 106949 (2019),
+        https://doi.org/10.1016/j.cpc.2019.106949
+
+    Args:
+        rcut (float): A cutoff for local region in angstroms. Should be
+            bigger than 1 angstrom.
+        nmax (int): The number of radial basis functions.
+        lmax (int): The maximum degree of spherical harmonics.
+        sigma (float): The standard deviation of the gaussians used to expand the
+            atomic density.
+        rbf (str): The radial basis functions to use. The available options are:
+
+            * "gto": Spherical gaussian type orbitals defined as :math:`g_{nl}(r) = \sum_{n'=1}^{n_\mathrm{max}}\,\\beta_{nn'l} r^l e^{-\\alpha_{n'l}r^2}`
+            * "polynomial": Polynomial basis defined as :math:`g_{n}(r) = \sum_{n'=1}^{n_\mathrm{max}}\,\\beta_{nn'} (r-r_\mathrm{cut})^{n'+2}`
+
+        periodic (bool): Determines whether the system is considered to be
+            periodic.
+        crossover (bool): Determines if crossover of atomic types should
+            be included in the power spectrum. If enabled, the power
+            spectrum is calculated over all unique species combinations Z
+            and Z'. If disabled, the power spectrum does not contain
+            cross-species information and is only run over each unique
+            species Z. Turned on by default to correspond to the original
+            definition
+    """
+    @requires(dscribe, "SOAPFeaturizer requires DScribe. Install from github.com/SINGROUP/dscribe")
+    def __init__(
+            self,
+            rcut,
+            nmax,
+            lmax,
+            sigma,
+            periodic,
+            rbf="gto",
+            crossover=True,
+            ):
+        self.rcut = rcut
+        self.nmax = nmax
+        self.lmax = lmax
+        self.sigma = sigma
+        self.rbf = rbf
+        self.periodic = periodic
+        self.crossover = crossover
+        self.adaptor = AseAtomsAdaptor()
+        self.length = None
+        self.atomic_numbers = None
+        self.soap = None
+        self.n_elements = None
+
+    def _check_fitted(self):
+        if not self.soap:
+            raise NotFittedError("Please fit SOAP before featurizing.")
+
+    def fit(self, X, y=None):
+        """
+        Fit the SOAP featurizer to a dataframe.
+
+        Args:
+            X ([SiteCollection]): For example, a list of pymatgen Structures.
+            y : unused (added for consistency with overridden method signature)
+
+        Returns:
+            self
+        """
+        # Check that pymatgen.Structures are provided
+        if not all([isinstance(struct, Structure) for struct in X]):
+            raise TypeError("This fit requires an array-like input of Pymatgen "
+                            "Structures and sites!")
+
+        elements = set()
+        for s in X:
+            c = s.composition.elements
+            for e in c:
+                if e.Z not in elements:
+                    elements.add(e.Z)
+        self.elements_sorted = sorted(list(elements))
+
+        self.atomic_numbers = elements
+        self.soap = SOAP_dscribe(species=self.atomic_numbers,
+                                 rcut=self.rcut,
+                                 nmax=self.nmax,
+                                 lmax=self.lmax,
+                                 sigma=self.sigma,
+                                 rbf=self.rbf,
+                                 periodic=self.periodic,
+                                 crossover=self.crossover,
+                                 average=False,
+                                 sparse=False)
+
+        self.length = self.soap.get_number_of_features()
+        return self
+
+    def featurize(self, s):
+        self._check_fitted()
+        s_ase = self.adaptor.get_atoms(s)
+        return self.soap.create(s_ase).tolist()[0]
+
+    def feature_labels(self):
+        self._check_fitted()
+        labels = []
+        for zi in self.elements_sorted:
+            for zj in self.elements_sorted:
+                for l in range(self.lmax+1):
+                    for ni in range(self.nmax):
+                        for nj in range(self.nmax):
+                            if nj >= ni and zj >= zi:
+                                labels.append("Z={},Z'={},l={},n={},n'={}".format(zi, zj, l, ni, nj))
+
+        return labels
+
+    def citations(self):
+        return ["@article{PhysRevB.87.184115,"
+                "title = {On representing chemical environments},"
+                "author = {Bart\'ok, Albert P. and Kondor, Risi and Cs\'anyi, "
+                "G\'abor},"
+                "journal = {Phys. Rev. B},"
+                "volume = {87},"
+                "issue = {18},"
+                "pages = {184115},"
+                "numpages = {16},"
+                "year = {2013},"
+                "month = {May},"
+                "publisher = {American Physical Society},"
+                "doi = {10.1103/PhysRevB.87.184115},"
+                "url = {https://link.aps.org/doi/10.1103/PhysRevB.87.184115}}",
+                "@Article{C6CP00415F,"
+                "author ={De, Sandip and BartÃ³k, Albert P. and CsÃ¡nyi, GÃ¡bor"
+                " and Ceriotti, Michele},"
+                "title  ={Comparing molecules and solids across structural and "
+                "alchemical space},"
+                "journal = {Phys. Chem. Chem. Phys.},"
+                "year = {2016},"
+                "volume = {18},"
+                "issue = {20},"
+                "pages = {13754-13769},"
+                "publisher = {The Royal Society of Chemistry},"
+                "doi = {10.1039/C6CP00415F},"
+                "url = {http://dx.doi.org/10.1039/C6CP00415F},}",
+
+                '@article{dscribe, '
+                'author = {Himanen, Lauri and J{\"a}ger, Marc O.~J. and '
+                'Morooka, Eiaki V. and Federici Canova, Filippo and Ranawat, '
+                'Yashasvi S. and Gao, David Z. and Rinke, Patrick and Foster, '
+                'Adam S.}, '
+                'title = {{DScribe: Library of descriptors for machine '
+                'learning in materials science}}, '
+                'journal = {Computer Physics Communications}, '
+                'year = {2019}, pages = {106949}, '
+                'doi = {https://doi.org/10.1016/j.cpc.2019.106949}}']
+
+    def implementors(self):
+        return ["Lauri Himanen and the DScribe team", "Alex Dunn"]

--- a/matminer/featurizers/tests/test_site.py
+++ b/matminer/featurizers/tests/test_site.py
@@ -11,8 +11,9 @@ from matminer.featurizers.site import AGNIFingerprints, \
     EwaldSiteEnergy, \
     VoronoiFingerprint, ChemEnvSiteFingerprint, \
     CoordinationNumber, ChemicalSRO, GaussianSymmFunc, \
-    GeneralizedRadialDistributionFunction, AngularFourierSeries, LocalPropertyDifference, \
-    BondOrientationalParameter, SiteElementalProperty, AverageBondLength, AverageBondAngle
+    GeneralizedRadialDistributionFunction, AngularFourierSeries, \
+    LocalPropertyDifference, SOAP, BondOrientationalParameter, \
+    SiteElementalProperty, AverageBondLength, AverageBondAngle
 from matminer.featurizers.deprecated import CrystalSiteFingerprint
 from matminer.featurizers.utils.grdf import Gaussian
 
@@ -35,6 +36,26 @@ class FingerprintTests(PymatgenTest):
             ["H", "He"], [[0,0,0],[0.5,0.5,0.5]],
             validate_proximity=False, to_unit_cell=False,
             coords_are_cartesian=False)
+        self.diamond = Structure(
+            Lattice([[2.189, 0, 1.264], [0.73, 2.064, 1.264],
+                     [0, 0, 2.528]]), ["C0+", "C0+"], [[2.554, 1.806, 4.423],
+                                                       [0.365, 0.258, 0.632]],
+            validate_proximity=False,
+            to_unit_cell=False, coords_are_cartesian=True,
+            site_properties=None)
+        self.nacl = Structure(
+            Lattice([[3.485, 0, 2.012], [1.162, 3.286, 2.012],
+                     [0, 0, 4.025]]), ["Na1+", "Cl1-"], [[0, 0, 0],
+                                                         [2.324, 1.643, 4.025]],
+            validate_proximity=False,
+            to_unit_cell=False, coords_are_cartesian=True,
+            site_properties=None)
+        self.ni3al = Structure(
+            Lattice([[3.52, 0, 0], [0, 3.52, 0], [0, 0, 3.52]]),
+            ["Al", ] + ["Ni"] * 3,
+            [[0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]],
+            validate_proximity=False, to_unit_cell=False,
+            coords_are_cartesian=False, site_properties=None)
 
     def test_simple_cubic(self):
         """Test with an easy structure"""
@@ -630,6 +651,38 @@ class FingerprintTests(PymatgenTest):
         ft = AverageBondAngle(CrystalNN())
         for i in range(len(self.b1.sites)):
             self.assertAlmostEqual(ft.featurize(self.b1, i)[0], np.pi / 2)
+
+    def test_SOAP(self):
+
+        def n_soap_feat(soaper):
+            n_elems = len(soaper.elements_sorted)
+            lmax = soap.lmax
+            nmax = soap.nmax
+            n_blocks = n_elems * (n_elems + 1)/2
+            n_element_features = int((lmax + 1) * nmax * (nmax + 1)/2)
+            return int(n_element_features * n_blocks)
+
+        # Test individual samples
+        soap = SOAP(rcut=3.0, nmax=4, lmax=2, sigma=1, periodic=True)
+        soap.fit([self.diamond])
+        v = soap.featurize(self.diamond, 0)
+        self.assertEqual(len(v), n_soap_feat(soap))
+
+        soap.fit([self.ni3al])
+        v = soap.featurize(self.ni3al, 0)
+        self.assertEqual(len(v), n_soap_feat(soap))
+
+        # Test dataframe fitting
+        df = pd.DataFrame({"s": [self.diamond, self.ni3al, self.nacl], 'idx': [0, 1, 0]})
+        soap.fit(df["s"])
+        df = soap.featurize_dataframe(df, ['s', 'idx'])
+        self.assertTupleEqual(df.shape, (3, n_soap_feat(soap)+2))
+
+        # Check that only the first has carbon features
+        carbon_label = df["Z=6,Z'=6,l=0,n=0,n'=0"]
+        self.assertTrue(carbon_label[0] != 0)
+        self.assertTrue(carbon_label[1] == 0)
+        self.assertTrue(carbon_label[2] == 0)
 
     def tearDown(self):
         del self.sc

--- a/matminer/featurizers/tests/test_structure.py
+++ b/matminer/featurizers/tests/test_structure.py
@@ -26,7 +26,7 @@ from matminer.featurizers.structure import DensityFeatures, \
     EwaldEnergy, BondFractions, BagofBonds, StructuralHeterogeneity, \
     MaximumPackingEfficiency, ChemicalOrdering, StructureComposition, \
     Dimensionality, XRDPowderPattern, CGCNNFeaturizer, JarvisCFID, \
-    SOAP, GlobalInstabilityIndex, \
+    GlobalInstabilityIndex, \
     StructuralComplexity
 
 # For the CGCNNFeaturizer
@@ -843,26 +843,6 @@ class StructureFeaturesTest(PymatgenTest):
         fvec = jcf.featurize(self.diamond)
         self.assertAlmostEqual(fvec[-1], 24, places=3)
         self.assertAlmostEqual(fvec[0], 0, places=3)
-
-    def test_SOAP(self):
-        # Test individual samples
-        soap = SOAP(n_max=4, l_max=2, r_cut=3.0)
-        soap.fit([self.diamond])
-        v = soap.featurize(self.diamond)
-        self.assertEqual(len(v), 30)
-        self.assertAlmostEqual(v[0], 5.299793243408203, places=6)
-
-        soap.fit([self.ni3al])
-        v = soap.featurize(self.ni3al)
-        self.assertEqual(len(v), 90)
-        self.assertAlmostEqual(v[0], 0.10329483449459076, places=6)
-
-        # Test dataframe fitting
-        df = pd.DataFrame({"s": [self.diamond, self.ni3al, self.nacl]})
-        soap.fit(df["s"])
-        df = soap.featurize_dataframe(df, "s", inplace=False)
-        self.assertTupleEqual(df.shape, (3, 451))
-        self.assertAlmostEqual(df["SOAP_449"].iloc[1], 3.029167413711548, places=5)
 
     def test_GlobalInstabilityIndex(self):
         # Test diamond and ni3al fail precheck


### PR DESCRIPTION
…iner.featurizers.site. Also improved the interface and added proper labels.

## Summary

* Moved the SOAP featurizer from matminer.featurizers.structure to matminer.featurizers.site. This makes sense since SOAP is inherently a local descriptor.
* If a user wants to describe a full structure, they should use e.g. SiteStatsFingerprint or roll their own custom kernel for comparing structures.
* Uses the latest DScribe interface 0.2.9.
* Support for almost all DScribe parameters (expect "sparse", since sparse matrices not supported).
* Updated SOAP regression test. The test is however quite primitive...

## TODO (if any)

* I'm not too familiar with how the matminer interface works, and what kind of tests should be performed. I only checked that the constructor, fit(), feature_labels(), and featurize() worked with very simple input. Could someone check that this implementation works as it should and that the code style is OK?