### PR TITLE
default mp dataretrieval to decode mp entities by default

### DIFF
--- a/matminer/data_retrieval/retrieve_MP.py
+++ b/matminer/data_retrieval/retrieve_MP.py
@@ -74,7 +74,7 @@ class MPDataRetrieval(BaseDataRetrieval):
             df = df.set_index("material_id")
         return df
 
-    def get_data(self, criteria, properties, mp_decode=False, index_mpid=True):
+    def get_data(self, criteria, properties, mp_decode=True, index_mpid=True):
         """
         Args:
             criteria: (str/dict) see MPRester.query() for a description of this


### PR DESCRIPTION
If mp_decode is set to False, it is not easy to tell how to (for example) get structure objects from the returned dictionaries. You cannot just Structure.from_dict them or monty decode them since they are within a {structure: <structure dict>} format.  mp_decode=True by default takes care of this, since most people just want the objects returned. 

If you want more advanced behavior, the option is still there to turn mp_decode=False. 