### PR TITLE
Add IntersticeDistribution class to site featurizer

### DIFF
--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -739,8 +739,10 @@ class IntersticeDistribution(BaseFeaturizer):
 
     For amorphous alloys (metallic glasses), the coordination environments are
     anisotropic, which can be reflected in the inequality of the interstices
-    present around an atom. To describe this anisotropy, we derive statistics
+    present around an atom. To describe the anisotropy, here we derive statistics
     of the interstices to featurize the interstice distribution around the atom.
+    Other methods can be grouping the interstices into histogram grids of fixed
+    bins and the features are then a vector of the values of the histograms.
 
     User note:
     This class is particularly designed for featuring the site-specific packing

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -704,7 +704,7 @@ class VoronoiFingerprint(BaseFeaturizer):
             '@article{peng2011, '
             'title={Structural signature of plastic deformation in metallic '
             'glasses}, '
-            'author={H L Peng, M Z Li, W H Wang}, '
+            'author={H L Peng, M Z Li and W H Wang}, '
             'journal={Physical Review Letters}, year={2011}}, '
             'pages = {135503}, volume = {106}, issue = {13}, '
             'doi = {10.1103/PhysRevLett.106.135503}}')

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -791,6 +791,7 @@ class IntersticeDistribution(BaseFeaturizer):
             struct, idx).values()
 
         nn_coords = np.array([nn['site'].coords for nn in n_w])
+        print(nn_coords)
 
         # Get center atom's radius and its nearest neighbors' radii
         center_r = MagpieData().get_elemental_properties(
@@ -842,10 +843,10 @@ class IntersticeDistribution(BaseFeaturizer):
     def analyze_area_interstice(nn_coords, nn_rs, convex_hull_simplices):
         """Analyze the area interstices in the neighbor convex hull facets.
         Args:
-            nn_coords (array-like): Nearest Neighbors' coordinates.
+            nn_coords (array-like, shape (N, 3)): Nearest Neighbors' coordinates
             nn_rs ([float]): Nearest Neighbors' radii.
-            convex_hull_simplices (array-like): Indices of points forming the
-                simplicial facets of the convex hull.
+            convex_hull_simplices (array-like, shape (M, 3)): Indices of points
+                forming the simplicial facets of convex hull.
         Returns:
             area_interstice_list ([float]): Area interstice list.
         """
@@ -863,6 +864,7 @@ class IntersticeDistribution(BaseFeaturizer):
                     np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
                 triangle_angles.append(t_a)
 
+            # calculate neighbors' packed area in the facet
             packed_area = 0
             for t_a, nn_r in zip(triangle_angles, facet_rs):
                 packed_area += t_a / 2 * pow(nn_r, 2)
@@ -882,12 +884,12 @@ class IntersticeDistribution(BaseFeaturizer):
         """Analyze the volume interstices in the tetrahedra formed by center
         atom and neighbor convex hull triplets.
         Args:
-            center_coords (array-like): Central atomic coordinates.
-            nn_coords (array-like): Nearest Neighbors' coordinates.
+            center_coords ([float]): Central atomic coordinates.
+            nn_coords (array-like, shape (N, 3)): Nearest Neighbors' coordinates
             center_r (float): central atom's radius.
             nn_rs ([float]): Nearest Neighbors' radii.
-            convex_hull_simplices (array-like): Indices of points forming the
-                simplicial facets of the convex hull.
+            convex_hull_simplices (array-like, shape (M, 3)): Indices of points
+                forming the simplicial facets of convex hull.
         Returns:
             volume_interstice_list ([float]): Volume interstice list.
         """
@@ -905,12 +907,12 @@ class IntersticeDistribution(BaseFeaturizer):
                                             center_coords]))
                 solid_angles.append(s_a)
 
-            # calculate neighbors' packed volume
+            # calculate neighbors' packed volume in the tetrahedron
             packed_volume = 0
             for s_a, nn_r in zip(solid_angles, facet_rs):
                 packed_volume += s_a / 3 * pow(nn_r, 3)
 
-            # add center atom's volume
+            # add center atom's volume in the tetrahedron
             center_solid_angle = solid_angle(center_coords, facet_coords)
             packed_volume += center_solid_angle / 3 * pow(center_r, 3)
 

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -756,20 +756,20 @@ class IntersticeDistribution(BaseFeaturizer):
         cutoff (float): cutoff distance in determining the potential
             neighbors for Voronoi tessellation analysis. (default: 6.5)
         interstice_types (str or [str]): interstice distribution types,
-            support sub-list of ['Dist', 'Area', 'Vol'].
+            support sub-list of ['dist', 'area', 'vol'].
         stats ([str]): statistics of distance/area/volume interstices.
         radius_type (str): interstice radius type. (default: "MiracleRadius")
     """
     def __init__(self, cutoff=6.5, interstice_types=None, stats=None,
                  radius_type='MiracleRadius'):
         self.cutoff = cutoff
-        self.interstice_types = ['Dist', 'Area', 'Vol'] \
+        self.interstice_types = ['dist', 'area', 'vol'] \
             if interstice_types is None else interstice_types
         if isinstance(self.interstice_types, str):
             self.interstice_types = [self.interstice_types]
         if all(t not in self.interstice_types for t in ['Dist', 'Area', 'Vol']):
             raise ValueError("interstice_types only support sub-list of "
-                             "['Dist', 'Area', 'Vol']")
+                             "['dist', 'area', 'vol']")
         self.stats = ['mean', 'std_dev', 'minimum', 'maximum'] \
             if stats is None else stats
         self.radius_type = radius_type
@@ -801,20 +801,20 @@ class IntersticeDistribution(BaseFeaturizer):
         # Get indices of the points forming the simplices in the triangulation
         convex_hull_simplices = ConvexHull(nn_coords).simplices
 
-        if 'Dist' in self.interstice_types:
+        if 'dist' in self.interstice_types:
             nn_dists = [nn['poly_info']['face_dist'] * 2 for nn in n_w]
             interstice_dist_list = IntersticeDistribution.\
                 analyze_dist_interstices(center_r, nn_rs, nn_dists)
             interstice_fps += [PropertyStats().calc_stat(
                 interstice_dist_list, stat) for stat in self.stats]
 
-        if 'Area' in self.interstice_types:
+        if 'area' in self.interstice_types:
             interstice_area_list = IntersticeDistribution.\
                 analyze_area_interstice(nn_coords, nn_rs, convex_hull_simplices)
             interstice_fps += [PropertyStats().calc_stat(
                 interstice_area_list, stat) for stat in self.stats]
 
-        if 'Vol' in self.interstice_types:
+        if 'vol' in self.interstice_types:
             interstice_vol_list = IntersticeDistribution.\
                 analyze_vol_interstice(struct[idx].coords, nn_coords,
                                        center_r, nn_rs, convex_hull_simplices)

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -717,7 +717,7 @@ class VoronoiFingerprint(BaseFeaturizer):
             'journal = {Nature Communications}, year = {2019}, '
             'pages = {5537}, volume = {10}, '
             'doi = {10.1038/s41467-019-13511-9}, '
-            'url = {https://doi.org/10.1038/s41467-019-13511-9}}')
+            'url = {https://www.nature.com/articles/s41467-019-13511-9}}')
         return [voronoi_citation, symm_idx_citation, nn_stats_citation]
 
     def implementors(self):
@@ -943,7 +943,7 @@ class IntersticeDistribution(BaseFeaturizer):
                 'journal = {Nature Communications}, year = {2019}, '
                 'pages = {5537}, volume = {10}, '
                 'doi = {10.1038/s41467-019-13511-9}, '
-                'url = {https://doi.org/10.1038/s41467-019-13511-9}}']
+                'url = {https://www.nature.com/articles/s41467-019-13511-9}}']
 
     def implementors(self):
         return ['Qi Wang']

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -803,7 +803,7 @@ class IntersticeDistribution(BaseFeaturizer):
         convex_hull_simplices = ConvexHull(nn_coords).simplices
 
         if 'dist' in self.interstice_types:
-            nn_dists = [nn['poly_info']['face_dist'] * 2 for nn in n_w]
+            nn_dists = [nn['face_dist'] * 2 for nn in n_w]
             interstice_dist_list = IntersticeDistribution.\
                 analyze_dist_interstices(center_r, nn_rs, nn_dists)
             interstice_fps += [PropertyStats().calc_stat(

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -792,7 +792,6 @@ class IntersticeDistribution(BaseFeaturizer):
             struct, idx).values()
 
         nn_coords = np.array([nn['site'].coords for nn in n_w])
-        print(nn_coords)
 
         # Get center atom's radius and its nearest neighbors' radii
         center_r = MagpieData().get_elemental_properties(
@@ -801,7 +800,7 @@ class IntersticeDistribution(BaseFeaturizer):
         nn_rs = np.array(MagpieData().get_elemental_properties(
             nn_els, self.radius_type)) / 100
 
-        # Get indices of the points forming the simplices in the triangulation
+        # Get indices of atoms forming the simplices of convex hull
         convex_hull_simplices = ConvexHull(nn_coords).simplices
 
         if 'dist' in self.interstice_types:

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -725,6 +725,30 @@ class VoronoiFingerprint(BaseFeaturizer):
 
 class IntersticeDistribution(BaseFeaturizer):
     """
+    Interstice distribution in the neighboring cluster around an atom site.
+    
+    The interstices are categorized to distance, area and volume interstices.
+    Each of these metrics is a measures of the relative amount of empty space
+    around each atom as determined using atomic sphere models. The distance
+    interstice is the fraction of a bonding line unoccupied by the atom spheres;
+    The area interstice is the unoccupied area within the triangulated surface
+    formed by atom triplets in convex hull formed by neighbors, and the volume
+    interstice is the unoccupied portion of a tetrahedron formed between the
+    central atom and neighbor atom triplets. Please refer to the original paper
+    for more details (Wang et al. Nature Communications 2019)
+
+    For amorphous alloys (metallic glasses), the coordination environments are
+    anisotropic, which can be reflected in the inequality of the interstices
+    present around an atom. To describe this anisotropy, we derive statistics
+    of the interstices to featurize the interstice distribution around the atom.
+
+    User note:
+    This class is particularly designed for featuring the site-specific packing
+    heterogeneity in metallic glasses, especially the all-metallic-element ones.
+    If non-metallic-elements are present in the structures, the interstice
+    estimates may have larger deviation from actual values (despite this
+    deviation is systematic and thus the interstice estimates can still be
+    used to represent the packing heterogeneity).
 
     Args:
         cutoff (float): cutoff distance in determining the potential

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -715,8 +715,9 @@ class VoronoiFingerprint(BaseFeaturizer):
             'glasses}, '
             'author = {Qi Wang and Anubhav Jain}, '
             'journal = {Nature Communications}, year = {2019}, '
-            'pages = {}, volume = {}, '
-            'doi = {10.1038/s41467-019-13511-9}, url = {}}')
+            'pages = {5537}, volume = {10}, '
+            'doi = {10.1038/s41467-019-13511-9}, '
+            'url = {https://doi.org/10.1038/s41467-019-13511-9}}')
         return [voronoi_citation, symm_idx_citation, nn_stats_citation]
 
     def implementors(self):
@@ -735,7 +736,7 @@ class IntersticeDistribution(BaseFeaturizer):
     formed by atom triplets in convex hull formed by neighbors, and the volume
     interstice is the unoccupied portion of a tetrahedron formed between the
     central atom and neighbor atom triplets. Please refer to the original paper
-    for more details (Wang et al. Nature Communications 2019)
+    for more details (Wang et al. Nat Commun 10, 5537 (2019))
 
     For amorphous alloys (metallic glasses), the coordination environments are
     anisotropic, which can be reflected in the inequality of the interstices
@@ -940,8 +941,9 @@ class IntersticeDistribution(BaseFeaturizer):
                 'glasses}, '
                 'author = {Qi Wang and Anubhav Jain},'
                 'journal = {Nature Communications}, year = {2019}, '
-                'pages = {}, volume = {}, '
-                'doi = {10.1038/s41467-019-13511-9}, url = {}}']
+                'pages = {5537}, volume = {10}, '
+                'doi = {10.1038/s41467-019-13511-9}, '
+                'url = {https://doi.org/10.1038/s41467-019-13511-9}}']
 
     def implementors(self):
         return ['Qi Wang']

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -727,7 +727,7 @@ class VoronoiFingerprint(BaseFeaturizer):
 class IntersticeDistribution(BaseFeaturizer):
     """
     Interstice distribution in the neighboring cluster around an atom site.
-    
+
     The interstices are categorized to distance, area and volume interstices.
     Each of these metrics is a measures of the relative amount of empty space
     around each atom as determined using atomic sphere models. The distance

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -694,12 +694,30 @@ class VoronoiFingerprint(BaseFeaturizer):
         return labels
 
     def citations(self):
-        citation = ['@book{okabe1992spatial,  '
-                    'title  = {Spatial tessellations}, '
-                    'author = {Okabe, Atsuyuki}, '
-                    'year   = {1992}, '
-                    'publisher = {Wiley Online Library}}']
-        return citation
+        voronoi_citation = (
+            '@book{okabe1992spatial,  '
+            'title  = {Spatial tessellations}, '
+            'author = {Okabe, Atsuyuki}, '
+            'year   = {1992}, '
+            'publisher = {Wiley Online Library}}')
+        symm_idx_citation = (
+            '@article{peng2011, '
+            'title={Structural signature of plastic deformation in metallic '
+            'glasses}, '
+            'author={H L Peng, M Z Li, W H Wang}, '
+            'journal={Physical Review Letters}, year={2011}}, '
+            'pages = {135503}, volume = {106}, issue = {13}, '
+            'doi = {10.1103/PhysRevLett.106.135503}}')
+        nn_stats_citation = (
+            '@article{Wang2019, '
+            'title = {A transferable machine-learning framework linking '
+            'interstice distribution and plastic heterogeneity in metallic '
+            'glasses}, '
+            'author = {Qi Wang and Anubhav Jain}, '
+            'journal = {Nature Communications}, year = {2019}, '
+            'pages = {}, volume = {}, '
+            'doi = {10.1038/s41467-019-13511-9}, url = {}}')
+        return [voronoi_citation, symm_idx_citation, nn_stats_citation]
 
     def implementors(self):
         return ['Qi Wang']
@@ -717,7 +735,7 @@ class IntersticeDistribution(BaseFeaturizer):
         radius_type (str): interstice radius type. (default: "MiracleRadius")
     """
     def __init__(self, cutoff=6.5, interstice_types=None, stats=None,
-                 radius_type="MiracleRadius"):
+                 radius_type='MiracleRadius'):
         self.cutoff = cutoff
         self.interstice_types = ['Dist', 'Area', 'Vol'] \
             if interstice_types is None else interstice_types
@@ -888,17 +906,14 @@ class IntersticeDistribution(BaseFeaturizer):
         return labels
 
     def citations(self):
-        return ["@article{Wang2019,"
-                "author = {Qi Wang and Anubhav Jain},"
-                "doi = {10.1038/s41467-019-13511-9},"
-                "journal = {Nature Communications},"
-                "pages = {},"
-                "title = {A transferable machine-learning framework linking "
-                "interstice distribution and plastic heterogeneity in metallic "
-                "glasses},"
-                "url = {},"
-                "volume = {},"
-                "year = {2019}"]
+        return ['@article{Wang2019,'
+                'title = {A transferable machine-learning framework linking '
+                'interstice distribution and plastic heterogeneity in metallic '
+                'glasses}, '
+                'author = {Qi Wang and Anubhav Jain},'
+                'journal = {Nature Communications}, year = {2019}, '
+                'pages = {}, volume = {}, '
+                'doi = {10.1038/s41467-019-13511-9}, url = {}}']
 
     def implementors(self):
         return ['Qi Wang']

--- a/matminer/featurizers/site.py
+++ b/matminer/featurizers/site.py
@@ -806,14 +806,14 @@ class IntersticeDistribution(BaseFeaturizer):
         """
         area_interstice_list = list()
 
-        angle_set = [(0, 1, 2), (1, 0, 2), (2, 0, 1)]
+        triplet_set = [(0, 1, 2), (1, 0, 2), (2, 0, 1)]
         for facet_indices in convex_hull_simplices:
             triangle_angles = list()
-            for angle in angle_set:
-                a = nn_coords[facet_indices[angle[1]]] - \
-                    nn_coords[facet_indices[angle[0]]]
-                b = nn_coords[facet_indices[angle[2]]] - \
-                    nn_coords[facet_indices[angle[0]]]
+            for triplet in triplet_set:
+                a = nn_coords[facet_indices[triplet[1]]] - \
+                    nn_coords[facet_indices[triplet[0]]]
+                b = nn_coords[facet_indices[triplet[2]]] - \
+                    nn_coords[facet_indices[triplet[0]]]
                 triangle_angle = np.arccos(
                     np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
                 triangle_angles.append(triangle_angle)
@@ -849,14 +849,14 @@ class IntersticeDistribution(BaseFeaturizer):
         """
         volume_interstice_list = list()
 
-        angle_set = [(0, 1, 2), (1, 0, 2), (2, 0, 1)]
+        triplet_set = [(0, 1, 2), (1, 0, 2), (2, 0, 1)]
         for facet_indices in convex_hull_simplices:
             solid_angles = list()
-            for idx, edge in zip(facet_indices, angle_set):
+            for triplet in zip(facet_indices, triplet_set):
                 s_a = solid_angle(
-                    nn_coords[facet_indices[edge[0]]],
-                    np.array([nn_coords[facet_indices[edge[0]]],
-                              nn_coords[facet_indices[edge[1]]],
+                    nn_coords[facet_indices[triplet[0]]],
+                    np.array([nn_coords[facet_indices[triplet[1]]],
+                              nn_coords[facet_indices[triplet[2]]],
                               center_coords]))
                 solid_angles.append(s_a)
 
@@ -920,7 +920,7 @@ class ChemicalSRO(BaseFeaturizer):
     A positive f_el indicates the "bonding" with the specific element
     is favored, at least in the target site;
     A negative f_el indicates the "bonding" is not favored, at least
-    in the target site
+    in the target site.
 
     Note that ChemicalSRO is only featurized for elements identified by
     "fit" (see following), thus "fit" must be called before "featurize",

--- a/matminer/featurizers/tests/test_site.py
+++ b/matminer/featurizers/tests/test_site.py
@@ -9,7 +9,7 @@ from pymatgen.analysis.local_env import VoronoiNN, JmolNN, CrystalNN
 from matminer.featurizers.site import AGNIFingerprints, \
     OPSiteFingerprint, CrystalNNFingerprint, \
     EwaldSiteEnergy, \
-    VoronoiFingerprint, ChemEnvSiteFingerprint, \
+    VoronoiFingerprint, IntersticeDistribution, ChemEnvSiteFingerprint, \
     CoordinationNumber, ChemicalSRO, GaussianSymmFunc, \
     GeneralizedRadialDistributionFunction, AngularFourierSeries, LocalPropertyDifference, \
     BondOrientationalParameter, SiteElementalProperty, AverageBondLength, AverageBondAngle
@@ -303,6 +303,66 @@ class FingerprintTests(PymatgenTest):
         self.assertAlmostEqual(vorofps['Voro_dist_std_dev'][0], 0.0)
         self.assertAlmostEqual(vorofps['Voro_dist_minimum'][0], 3.52)
         self.assertAlmostEqual(vorofps['Voro_dist_maximum'][0], 3.52)
+
+    def test_interstice_distribution_of_crystal(self):
+        bcc_li = Structure(Lattice([[3.51, 0, 0], [0, 3.51, 0], [0, 0, 3.51]]),
+                           ["Li"] * 2, [[0, 0, 0], [0.5, 0.5, 0.5]])
+        df_bcc_li= pd.DataFrame({'struct': [bcc_li], 'site': [1]})
+
+        interstice_distribution = IntersticeDistribution()
+        intersticefp = interstice_distribution.featurize_dataframe(
+            df_bcc_li, ['struct', 'site'])
+
+        self.assertAlmostEqual(intersticefp['Interstice_vol_mean'][0], 0.32, 2)
+        self.assertAlmostEqual(intersticefp['Interstice_vol_std_dev'][0], 0)
+        self.assertAlmostEqual(intersticefp['Interstice_vol_minimum'][0], 0.32, 2)
+        self.assertAlmostEqual(intersticefp['Interstice_vol_maximum'][0], 0.32, 2)
+        self.assertAlmostEqual(intersticefp['Interstice_area_mean'][0], 0.16682, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_area_std_dev'][0], 0)
+        self.assertAlmostEqual(intersticefp['Interstice_area_minimum'][0], 0.16682, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_area_maximum'][0], 0.16682, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_dist_mean'][0], 0.06621, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_dist_std_dev'][0], 0.07655, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_dist_minimum'][0], 0, 3)
+        self.assertAlmostEqual(intersticefp['Interstice_dist_maximum'][0], 0.15461, 5)
+
+    def test_interstice_distribution_of_glass(self):
+        cuzr_glass = Structure(Lattice([[25, 0, 0], [0, 25, 0], [0, 0, 25]]),
+                           ["Cu", "Cu", "Cu", "Cu", "Cu", "Zr", "Cu", "Zr",
+                            "Cu", "Zr", "Cu", "Zr", "Cu", "Cu"],
+                           [[11.81159679, 16.49480537, 21.69139442],
+                            [11.16777208, 17.87850033, 18.57877144],
+                            [12.22394796, 15.83218325, 19.37763412],
+                            [13.07053548, 14.34025424, 21.77557646],
+                            [10.78147725, 19.61647494, 20.77595531],
+                            [10.87541011, 14.65986432, 23.61517624],
+                            [12.76631002, 18.41479521, 20.46717947],
+                            [14.63911675, 16.47487037, 20.52671362],
+                            [14.2470256, 18.44215167, 22.56257566],
+                            [9.38050168, 16.87974592, 20.51885879],
+                            [10.66332986, 14.43900833, 20.545186],
+                            [11.57096832, 18.79848982, 23.26073408],
+                            [13.27048138, 16.38613795, 23.59697472],
+                            [9.55774984, 17.09220537, 23.1856528]],
+                           coords_are_cartesian=True)
+        df_glass= pd.DataFrame({'struct': [cuzr_glass], 'site': [0]})
+
+        interstice_distribution = IntersticeDistribution(cutoff=5)
+        intersticefp = interstice_distribution.featurize_dataframe(
+            df_glass, ['struct', 'site'])
+
+        self.assertAlmostEqual(intersticefp['Interstice_vol_mean'][0], 0.28905, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_vol_std_dev'][0], 0.04037, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_vol_minimum'][0], 0.21672, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_vol_maximum'][0], 0.39084, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_area_mean'][0], 0.16070, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_area_std_dev'][0], 0.05245, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_area_minimum'][0], 0.07132, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_area_maximum'][0], 0.26953, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_dist_mean'][0], 0.08154, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_dist_std_dev'][0], 0.14778, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_dist_minimum'][0], -0.04668, 5)
+        self.assertAlmostEqual(intersticefp['Interstice_dist_maximum'][0], 0.37565, 5)
 
     def test_chemicalSRO(self):
         df_sc = pd.DataFrame({'struct': [self.sc], 'site': [0]})

--- a/matminer/featurizers/tests/test_site.py
+++ b/matminer/featurizers/tests/test_site.py
@@ -347,7 +347,7 @@ class FingerprintTests(PymatgenTest):
                            coords_are_cartesian=True)
         df_glass= pd.DataFrame({'struct': [cuzr_glass], 'site': [0]})
 
-        interstice_distribution = IntersticeDistribution(cutoff=5)
+        interstice_distribution = IntersticeDistribution()
         intersticefp = interstice_distribution.featurize_dataframe(
             df_glass, ['struct', 'site'])
 


### PR DESCRIPTION
## Summary

Added a new `IntersticeDistribution` class to featurize the interstice distribution around atom sites in metallic glasses (as well as in crystals formed by metallic elements), based on our recent paper https://www.nature.com/articles/s41467-019-13511-9. 

The interstices are categorized to distance, area and volume interstices. Each of these metrics is a measures of the relative amount of empty space around each atom as determined using atomic sphere models. 

* Added functions to calculate distance, area and volume interstices.
* Added unit tests of featurizing atom sites in both crystal and glass.
* Also added the paper citation to my previously written VoronoiFingerprint class that uses same statistical methodology.
