### PR TITLE
Turn off progress bar for .transform

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -250,7 +250,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     def transform(self, X):
         """Compute features for a list of inputs"""
 
-        return self.featurize_many(X, ignore_errors=True)
+        return self.featurize_many(X, ignore_errors=True, pbar=False)
 
     def fit_featurize_dataframe(self, df, col_id, fit_args=None,
                                 *args, **kwargs):


### PR DESCRIPTION
## Summary

There is currently no way to turn the progress bar off if you use a Featurizer in a scikit-learn pipeline. This PR makes turns off the progress bar by default to match with the style of other scikit-learn tools (which are all quiet). 

## TODO (if any)