### PR TITLE
Allow ElementProperty.featurize use pmg structure

### DIFF
--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -187,6 +187,7 @@ class ElementProperty(BaseFeaturizer):
 
         all_attributes = []
         
+        # Allow pmg structure
         if isinstance(comp, Structure):
             comp = comp.composition
 

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -8,7 +8,7 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-from pymatgen import Element, MPRester
+from pymatgen import Element, MPRester, Structure
 from pymatgen.core.composition import Composition
 from pymatgen.core.molecular_orbitals import MolecularOrbitals
 from pymatgen.core.periodic_table import get_el_sp
@@ -179,13 +179,16 @@ class ElementProperty(BaseFeaturizer):
         Get elemental property attributes
 
         Args:
-            comp: Pymatgen composition object
+            comp: Pymatgen structure or composition object
 
         Returns:
             all_attributes: Specified property statistics of features
         """
 
         all_attributes = []
+        
+        if isinstance(comp, Structure):
+            comp = comp.composition
 
         # Get the element names and fractions
         elements, fractions = zip(*comp.element_composition.items())

--- a/matminer/featurizers/composition.py
+++ b/matminer/featurizers/composition.py
@@ -186,8 +186,7 @@ class ElementProperty(BaseFeaturizer):
         """
 
         all_attributes = []
-        
-        # Allow pmg structure
+
         if isinstance(comp, Structure):
             comp = comp.composition
 


### PR DESCRIPTION
I want to compute a list of features from different classes (ElementProperty, OxidationStates, DensityFeatures, etc). It seems easier if all of them take pmg structure as an argument in the featurize function. This case is to allow this for ElementProperty.