### PR TITLE
Fix hashes for expt_* matbench datasets, accounting for 1128G typo

### DIFF
--- a/matminer/datasets/dataset_metadata.json
+++ b/matminer/datasets/dataset_metadata.json
@@ -754,7 +754,7 @@
     "num_entries": 4604,
     "reference": "Y. Zhuo, A. Masouri Tehrani, J. Brgoch (2018) Predicting the Band Gaps of Inorganic Solids by Machine Learning J. Phys. Chem. Lett. 2018, 9, 7, 1668-1673 https:doi.org/10.1021/acs.jpclett.8b00124.",
     "url": "https://ml.materialsproject.org/matbench_expt_gap.json.gz",
-    "hash": "1e6816fb8e7132535b76cdac458c4d53944eca97e1ecb68e6a8fd853c9cedc3a"
+    "hash": "783e7d1461eb83b00b2f2942da4b95fda5e58a0d1ae26b581c24cf8a82ca75b2"
   },
   "matbench_expt_is_metal": {
     "bibtex_refs": [
@@ -769,7 +769,7 @@
     "num_entries": 4921,
     "reference": "Y. Zhuo, A. Masouri Tehrani, J. Brgoch (2018) Predicting the Band Gaps of Inorganic Solids by Machine Learning J. Phys. Chem. Lett. 2018, 9, 7, 1668-1673 \n https//:doi.org/10.1021/acs.jpclett.8b00124.",
     "url": "https://ml.materialsproject.org/matbench_expt_is_metal.json.gz",
-    "hash": "80fb0854cff5d4657d812793f4748d5c23a9407f6c59bcf5b86c818ebaa6910f"
+    "hash": "8f2a4f9bacdcbc5c2c73615629ee7986f09d39bed40ba7db52b61b2889730887"
   },
   "matbench_phonons": {
     "bibtex_refs": [

--- a/matminer/featurizers/tests/test_composition.py
+++ b/matminer/featurizers/tests/test_composition.py
@@ -207,14 +207,14 @@ class CompositionFeaturesTest(PymatgenTest):
         if not mpr.api_key:
             raise SkipTest("Materials Project API key not set; Skipping cohesive energy test")
         df_cohesive_energy = CohesiveEnergy().featurize_dataframe(self.df, col_id="composition")
-        self.assertAlmostEqual(df_cohesive_energy["cohesive energy"][0], 5.15768, 2)
+        self.assertAlmostEqual(df_cohesive_energy["cohesive energy"][0], 5.179, 2)
 
     def test_cohesive_energy_mp(self):
         mpr = MPRester()
         if not mpr.api_key:
             raise SkipTest("Materials Project API key not set; Skipping cohesive energy test")
         df_cohesive_energy = CohesiveEnergyMP().featurize_dataframe(self.df, col_id="composition")
-        self.assertAlmostEqual(df_cohesive_energy["cohesive energy (MP)"][0], 5.945, 2)
+        self.assertAlmostEqual(df_cohesive_energy["cohesive energy (MP)"][0], 5.978, 2)
 
     def test_miedema_all(self):
         df = pd.DataFrame({"composition": [Composition("TiZr"),


### PR DESCRIPTION
Also, correct cohesive energy test