### PR TITLE
make BaseFeaturizer an ABC with abstractmethods

### DIFF
--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -3,19 +3,20 @@ from __future__ import division, unicode_literals
 import sys
 import traceback
 import warnings
-from multiprocessing import Pool, cpu_count
+from abc import ABC, abstractmethod
 from functools import partial
+from multiprocessing import Pool, cpu_count
 
 import numpy as np
 import pandas as pd
-from six import string_types, reraise
-from sklearn.base import TransformerMixin, BaseEstimator, is_classifier
+from six import reraise, string_types
+from sklearn.base import BaseEstimator, TransformerMixin, is_classifier
 from tqdm.auto import tqdm
 
 from matminer.utils.utils import homogenize_multiindex
 
 
-class BaseFeaturizer(BaseEstimator, TransformerMixin):
+class BaseFeaturizer(BaseEstimator, TransformerMixin, ABC):
     """
     Abstract class to calculate features from raw materials input data
     such a compound formula or a pymatgen crystal structure or
@@ -99,7 +100,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
     An additional factor to consider is the chunksize for data parallelisation.
     For lightweight computational tasks, the overhead associated with passing
-    data from `multiprocessing.Pool.map()` to the function being parallelised
+    data from `multiprocessing.Pool.map()` to the function being parallelized
     can increase the time taken for all tasks to be completed. By setting
     the `self._chunksize` argument, the overhead associated with passing data
     to the tasks can be reduced. Note that there is only an advantage to using
@@ -108,7 +109,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     itself. By default, we allow the Python multiprocessing library to determine
     the chunk size automatically based on the size of the list being featurized.
     You may want to specify a small chunk size for computationally-expensive
-    featurizers, which will enable better distribution of taks across threads.
+    featurizers, which will enable better distribution of tasks across threads.
     In contrast, for more lightweight featurizers, it is recommended that
     the implementor trial a range of chunksize values to find the optimum.
     As a general rule of thumb, if the featurize function takes 0.1 seconds or
@@ -140,7 +141,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
     """
 
     def set_n_jobs(self, n_jobs):
-        """Set the number of threads for this """
+        """Set the number of threads for this."""
         self._n_jobs = n_jobs
 
     @property
@@ -503,6 +504,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
                        "featurize_many(), featurize_dataframe(), etc.)."
                 reraise(type(e), type(e)(msg), sys.exc_info()[2])
 
+    @abstractmethod
     def featurize(self, *x):
         """
         Main featurizer function, which has to be implemented
@@ -517,6 +519,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
         raise NotImplementedError("featurize() is not defined!")
 
+    @abstractmethod
     def feature_labels(self):
         """
         Generate attribute names.
@@ -527,6 +530,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
         raise NotImplementedError("feature_labels() is not defined!")
 
+    @abstractmethod
     def citations(self):
         """
         Citation(s) and reference(s) for this feature.
@@ -538,6 +542,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin):
 
         raise NotImplementedError("citations() is not defined!")
 
+    @abstractmethod
     def implementors(self):
         """
         List of implementors of the feature.

--- a/matminer/featurizers/dos.py
+++ b/matminer/featurizers/dos.py
@@ -77,6 +77,12 @@ class SiteDOS(BaseFeaturizer):
                 labels.append('{}_{}'.format(edge, score))
         return labels
 
+    def citations(self):
+        return []
+
+    def implementors(self):
+        return []
+
 
 class DOSFeaturizer(BaseFeaturizer):
     """
@@ -173,6 +179,9 @@ class DOSFeaturizer(BaseFeaturizer):
                 i += 1
 
         return labels
+
+    def citations(self):
+        return []
 
     def implementors(self):
         return ['Maxwell Dylla', 'Alireza Faghaninia', 'Anubhav Jain']
@@ -373,6 +382,9 @@ class Hybridization(BaseFeaturizer):
                 labels.append('{}_{}'.format(ex, hybrid))
         return labels
 
+    def citations(self):
+        return []
+
     def implementors(self):
         return ['Alireza Faghaninia', 'Anubhav Jain', 'Maxwell Dylla']
 
@@ -446,6 +458,9 @@ class DosAsymmetry(BaseFeaturizer):
         """Returns the labels for each of the features.
         """
         return ['dos_asymmetry']
+
+    def citations(self):
+        return []
 
     def implementors(self):
         return ['Maxwell Dylla']

--- a/matminer/featurizers/tests/test_base.py
+++ b/matminer/featurizers/tests/test_base.py
@@ -85,6 +85,12 @@ class MultiArgs2(BaseFeaturizer):
     def feature_labels(self):
         return ['y2']
 
+    def citations(self):
+        return []
+
+    def implementors(self):
+        return []
+
 
 class FittableFeaturizer(BaseFeaturizer):
     """
@@ -117,6 +123,12 @@ class MultiTypeFeaturizer(BaseFeaturizer):
 
     def feature_labels(self):
         return ['label', 'int_label']
+
+    def citations(self):
+        return []
+
+    def implementors(self):
+        return []
 
 
 class TestBaseClass(PymatgenTest):


### PR DESCRIPTION
Addresses the minor point in #503.

Question: Shouldn't `BaseFeaturizer.fit` be an `abstractmethod` and raise `NotImplementedError`? Right now it's

```py
    def fit(self, X, y=None, **fit_kwargs):
        """Update the parameters of this featurizer based on available data

        Args:
            X - [list of tuples], training data
        Returns:
            self
            """
        return self
```