### PR TITLE
Add thermoelectric DB as dataset, update CI

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -1,14 +1,13 @@
-# This workflow runs only on Ubuntu and aims to be more complete than the Mac and Windows workflows.
-# In particular, Openbabel and many of the external command line dependencies are included for testing.defaults:
-# The ext package is also only tested in this workflow. Coverage is also computed based on this platform.
-name: Release
+name: Full test
 
 
 # Run this workflow only on release
 on:
-  release:
-    types:
-      - created
+  - release:
+      types: [published, created, released]
+  - workflow_dispatch
+  - schedule:
+      - cron: "0 12 1 * *"
 
 jobs:
 

--- a/matminer/datasets/dataset_metadata.json
+++ b/matminer/datasets/dataset_metadata.json
@@ -915,10 +915,35 @@
     },
     "description": "Matbench v0.1 test dataset for predicting steel yield strengths from chemical composition alone. Retrieved from Citrine informatics. Deduplicated. For benchmarking w/ nested cross validation, the order of the dataset must be identical to the retrieved data; refer to the Automatminer/Matbench publication for more details.",
     "file_type": "json.gz",
-    "hash": "",
     "num_entries": 312,
     "reference": "https://citrination.com/datasets/153092/",
     "url": "https://ml.materialsproject.org/projects/matbench_steels.json.gz",
     "hash": "473bc4957b2ea5e6465aef84bc29bb48ac34db27d69ea4ec5f508745c6fae252"
+  },
+    "ucsb_thermoelectrics": {
+    "bibtex_refs": [
+      "@article{Gaultois2013,\n  doi = {10.1021/cm400893e},\n  url = {https://doi.org/10.1021/cm400893e},\n  year = {2013},\n  month = may,\n  publisher = {American Chemical Society ({ACS})},\n  volume = {25},\n  number = {15},\n  pages = {2911--2920},\n  author = {Michael W. Gaultois and Taylor D. Sparks and Christopher K. H. Borg and Ram Seshadri and William D. Bonificio and David R. Clarke},\n  title = {Data-Driven Review of Thermoelectric Materials: Performance and Resource Considerations},\n  journal = {Chemistry of Materials}\n}",
+      "@misc{Citrine Informatics,\ntitle = {UCSB Thermoelectrics Database},\nhowpublished = {\\url{https://citrination.com/datasets/150557/},\n}"
+    ],
+    "columns": {
+      "composition": "Chemical formula.",
+      "crystallinity": "Either single crystal, polycrystalline, or nanoparticles.",
+      "synthesis": "Brief string describing the synthesis method",
+      "spacegroup": "Spacegroup number, if available",
+      "rho (ohm.cm)": "Electrical resistivity, in ohm.cm",
+      "S [muV/K]": "Seebeck coefficient, in microVolts/K, if available",
+      "PF [W/mK^2]": "Thermoelectric power factor, conductivity * Seebeck^2, in [W/mK^2] if available",
+      "zT": "Thermoelectric figure of merit, PF * T/K, unitless, if available",
+      "kappa [W/mK]": "Thermal conductivity in Watt/ meter * Kelvin, if available",
+      "sigma [S/cm]": "Electrical conductivity, in Siemens/cm, if available",
+      "T [K]": "Temperature in Kelvin at which these properties were obtained, if available",
+      "src": "Original source of the recording. To cite the aggregator of the data, see the bibtext_refs section of this metadata."
+    },
+    "description": "Database of ~1,100 experimental thermoelectric materials from UCSB aggregated from 108 source publications and personal communications. Downloaded from Citrine. Source UCSB webpage is http://www.mrl.ucsb.edu:8080/datamine/thermoelectric.jsp. See reference for more information on original data aggregation. No duplicate entries are present, but each src may result in multiple measurements of the same materials' properties at different temperatures or conditions.",
+    "file_type": "json.gz",
+    "num_entries": 1093,
+    "reference": "https://citrination.com/datasets/150557/",
+    "url": "https://ndownloader.figshare.com/files/28333845",
+    "hash": "7d0c9c74fd52995b876bd251a7732b5498314702441fa463197fb492be68ecc0"
   }
 }

--- a/matminer/datasets/tests/base.py
+++ b/matminer/datasets/tests/base.py
@@ -54,6 +54,7 @@ class DatasetTest(unittest.TestCase):
             "matbench_expt_is_metal",
             "matbench_phonons",
             "matbench_steels",
+            "ucsb_thermoelectrics",
         ]
         self.dataset_attributes = [
             "file_type",

--- a/matminer/datasets/tests/test_datasets.py
+++ b/matminer/datasets/tests/test_datasets.py
@@ -638,7 +638,6 @@ class MatminerDatasetsTest(DataSetsTest):
 
         self.universal_dataset_check("ricci_boltztrap_mp_tabular", object_headers, numeric_headers)
 
-
     def test_ucsb_thermoelectrics(self):
         object_headers = ["composition", "crystallinity", "synthesis", "src"]
 

--- a/matminer/datasets/tests/test_datasets.py
+++ b/matminer/datasets/tests/test_datasets.py
@@ -639,6 +639,22 @@ class MatminerDatasetsTest(DataSetsTest):
         self.universal_dataset_check("ricci_boltztrap_mp_tabular", object_headers, numeric_headers)
 
 
+    def test_ucsb_thermoelectrics(self):
+        object_headers = ["composition", "crystallinity", "synthesis", "src"]
+
+        numeric_headers = [
+            "spacegroup",
+            "rho (ohm.cm)",
+            "S [muV/K]",
+            "PF [W/mK^2]",
+            "zT",
+            "kappa [W/mK]",
+            "sigma [S/cm]",
+            "T [K]",
+        ]
+        self.universal_dataset_check("ucsb_thermoelectrics", object_headers, numeric_headers)
+
+
 class MatbenchDatasetsTest(DataSetsTest):
     """
     Matbench datasets are tested here.


### PR DESCRIPTION
Allow full tests to run on manual triggering, and also 1x month automatically

Add UCSB thermoelectrics database to matminer's datasets, including test


the formatted and cleaned dataset:

```python
df = load_dataset("ucsb_thermoelectrics")
```

```
Out[5]: 
                    composition    crystallinity                         synthesis  spacegroup  rho (ohm.cm)  S [muV/K]  PF [W/mK^2]        zT  kappa [W/mK]  sigma [S/cm]   T [K]                                              src
1              Ti0.99Nb0.01NiSn  Polycrystalline                Arc-melted, vacuum       216.0      0.001240   -192.458     0.002987  0.203822      5.861700     806.39000   400.0  http://dx.doi.org/10.1016/j.jallcom.2008.02.041
2                      Cu1.98Se  Polycrystalline                    Melted, vacuum       225.0      0.003250    201.500     0.001249  1.230837      1.015000     307.69000  1000.0               http://dx.doi.org/10.1038/nmat3280
3                        Bi2Te3   Single crystal                            Melted       166.0      0.000450   -174.000     0.006728  0.502500      4.016716    2222.20000   300.0     http://dx.doi.org/10.1201/9781420049718.ch19
4                    Cr1.3Mo6S8  Polycrystalline      Solid state reaction, vacuum         2.0      0.000693     51.220     0.000378  0.098456      2.690500    1442.40000   700.0      http://dx.doi.org/10.1007/s11664-009-0975-0
5                        LaNiO3  Polycrystalline  Evaporate nitrates (1173 K, air)       167.0      0.004601    -25.760     0.000014       NaN           NaN     217.33000   700.0          http://dx.doi.org/10.1557/PROC-793-S3.3
                         ...              ...                               ...         ...           ...        ...          ...       ...           ...           ...     ...                                              ...
1089       Pb0.97Sr0.02TeNa0.01  Polycrystalline                           Melting       225.0      0.003012    263.000     0.002296  1.560670      1.030000     332.00000   700.0            http://dx.doi.org/10.1038/nature11439
1090                     CaMnO3  Polycrystalline         Solid state reaction, air        62.0      6.975398   -476.683     0.000003  0.000327      2.989800       0.14336   300.0         http://dx.doi.org/10.1006/jssc.1995.1384
1091             Ca0.9Sm0.1MnO3  Polycrystalline         Solid state reaction, air        62.0      0.007469   -105.968     0.000150       NaN           NaN     133.89000   400.0         http://dx.doi.org/10.1006/jssc.1995.1384
1092  Si0.79936Ge0.19984B0.0008  Polycrystalline                Vacuum hot pressed       227.0      0.001333    127.631     0.001222  0.084451      4.339760     749.96000   300.0               http://dx.doi.org/10.1063/1.348408
1093                     LaCoO3  Polycrystalline              Solid state reaction        15.0      0.000984     15.700     0.000025       NaN           NaN    1016.20000  1000.0     http://dx.doi.org/10.1016/j.jssc.2008.08.078
```