### PR TITLE
Bugfix for installing package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
             'matminer.utils.data_files': ['*.cif', '*.csv', '*.tsv', '*.json',
                                           'magpie_elementdata/*.table',
                                           'jarvis/*.json', '*.txt']},
+        include_package_data=True,
         zip_safe=False,
         install_requires=reqs_list,
         extras_require=extras_dict,


### PR DESCRIPTION
## Summary

I was getting a file not found error when using the `SineCoulombMatrix` featurizer because [cn_target_motif_op.yaml](https://github.com/hackingmaterials/matminer/blob/main/matminer/featurizers/site/cn_target_motif_op.yaml) wasn't being included when I pip installed matminer. It looks like `MANIFEST.in` controls this, so I added a line to `setup.py` to make sure package data is included. Now it seems to be working.

* Fix pip install package data

I'm using python 3.7.10, pymatgen v2022.0.8, and the latest version of matminer.