### PR TITLE
Fix package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         packages=find_packages(),
         package_data={
             'matminer.datasets': ['*.json'],
-            'matminer.featurizers': ["*.yaml"],
+            'matminer.featurizers': ["*/*.yaml"],
             'matminer.utils.data_files': ['*.cif', '*.csv', '*.tsv', '*.json',
                                           'magpie_elementdata/*.table',
                                           'jarvis/*.json', '*.txt']},


### PR DESCRIPTION
## Summary

New package layout broke installing matminer using pip without an editable installation. I've corrected `package_data` in setup.py which hopefully should fix this issue (although it is hard to test without releasing a new pypi version).

I guess this is also related to #641 