### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -26,6 +26,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Start mongodb server - the nuclear option
+      run: sudo docker run --name mongo -d -p 27017:27017 mongo
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -35,8 +39,6 @@ jobs:
 #      uses: supercharge/mongodb-github-action@1.6.0
 #      with:
 #        mongodb-version: ${{ matrix.mongodb-version }}
-    - name: Start mongodb server - the nuclear option
-      run: sudo docker run --name mongo -d -p 27017:27017 mongo
 
     - name: Run full tests including dataset downloads
       run: |

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -16,6 +16,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
+
     env:
       PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}
       MPDS_KEY: ${{ secrets.MPDS_KEY }}
@@ -26,19 +32,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Start mongodb server - the nuclear option
-      run: sudo docker run --name mongo -d -p 27017:27017 mongo
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
-#    - name: Start MongoDB ${{ matrix.mongodb-version }}
-#      uses: supercharge/mongodb-github-action@1.6.0
-#      with:
-#        mongodb-version: ${{ matrix.mongodb-version }}
 
     - name: Run full tests including dataset downloads
       run: |

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -13,7 +13,6 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.7, 3.8]
-        mongodb-version: ['4.0', '4.2']
 
     runs-on: ubuntu-latest
 
@@ -32,10 +31,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Start MongoDB ${{ matrix.mongodb-version }}
-      uses: supercharge/mongodb-github-action@1.6.0
-      with:
-        mongodb-version: ${{ matrix.mongodb-version }}
+#    - name: Start MongoDB ${{ matrix.mongodb-version }}
+#      uses: supercharge/mongodb-github-action@1.6.0
+#      with:
+#        mongodb-version: ${{ matrix.mongodb-version }}
+    - name: Start mongodb server - the nuclear option
+      run: sudo docker run --name mongo -d -p 27017:27017 mongo
 
     - name: Run full tests including dataset downloads
       run: |

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -13,6 +13,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.7, 3.8]
+        mongodb-version: ['4.0', '4.2']
 
     runs-on: ubuntu-latest
 
@@ -30,11 +31,17 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Start MongoDB ${{ matrix.mongodb-version }}
+      uses: supercharge/mongodb-github-action@1.6.0
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
+
     - name: Run full tests including dataset downloads
       run: |
         python3 -m venv test_env
         . test_env/bin/activate
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-optional.txt -r requirements-dev.txt
-        pip install -e .
+        pip install .
         pytest --cov=matminer matminer

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@ include LICENSE *.txt
 include matminer/datasets/dataset_metadata.json
 include matminer/featurizers/*/*.yaml
 include matminer/featurizers/*/*.json
-include matminer/featurizers/site/*.json
 include matminer/utils/data_files/*.csv
 include matminer/utils/data_files/*.tsv
 include matminer/utils/data_files/*.json
@@ -11,5 +10,6 @@ include matminer/utils/data_files/jarvis/*
 include matminer/utils/data_files/*.txt
 recursive-include matminer *
 recursive-exclude matminer *.pyc
+recursive-exclude matminer *.json.gz
 recursive-include docs *
 recursive-exclude docs *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include LICENSE *.txt
-include matminer/datasets/*.csv
+include matminer/datasets/dataset_metadata.json
 include matminer/featurizers/*/*.yaml
+include matminer/featurizers/*/*.json
+include matminer/featurizers/site/*.json
 include matminer/utils/data_files/*.csv
 include matminer/utils/data_files/*.tsv
 include matminer/utils/data_files/*.json

--- a/matminer/data_retrieval/tests/test_retrieve_MongoDB.py
+++ b/matminer/data_retrieval/tests/test_retrieve_MongoDB.py
@@ -1,12 +1,19 @@
-# coding: utf-8
-
-
 import unittest
 
-from matminer.data_retrieval.retrieve_MongoDB import clean_projection, remove_ints
+from pymongo import MongoClient
+from pymatgen.util.testing import PymatgenTest
+
+from matminer.data_retrieval.retrieve_MongoDB import \
+    clean_projection, \
+    remove_ints, \
+    MongoDataRetrieval
+from matminer.data_retrieval.tests.base import on_ci
+
+import pandas as pd
 
 
-class MongoDataRetrievalTest(unittest.TestCase):
+class MongoDataRetrievalTest(PymatgenTest):
+
     def test_cleaned_projection(self):
         p = ["n.o.e", "n.o.e.l", "a.b", "a.b.c", "m", "m.b"]
         result = clean_projection(p)
@@ -19,3 +26,45 @@ class MongoDataRetrievalTest(unittest.TestCase):
     def test_remove_ints(self):
         self.assertEqual(remove_ints("a.1"), "a")
         self.assertEqual(remove_ints("a.1.x"), "a.x")
+
+    @unittest.skipIf(
+        not on_ci,
+        "MongoDataRetrievalTest configured only to run on CI by default"
+    )
+    def test_get_dataframe(self):
+        db = MongoClient("localhost", 27017, username="admin", password="password").test_db
+        c = db.test_collection
+        docs = [
+            {"some": {"nested": {"result": 14.5}},
+             "other": "notnestedresult",
+             "final": 16.938475 + i,
+             "array": [1.4, 5.6, 11.2, 1.1],
+             "valid": True
+             }
+            for i in range(5)
+        ]
+
+        docs[-1]["valid"] = False
+        c.insert_many(docs)
+
+        mdr = MongoDataRetrieval(c)
+
+        df = mdr.get_dataframe(
+            criteria={"valid": True},
+            properties=["some.nested.result", "other", "final", "array", "valid"]
+        )
+
+        self.assertTrue((df["some.nested.result"] == 14.5).all())
+        self.assertTrue((df["other"] == "notnestedresult").all())
+
+        floats = df["final"] != 16.938475
+        self.assertTrue(floats.any() and not floats.all())
+
+        self.assertArrayAlmostEqual(df["array"].iloc[0], [1.4, 5.6, 11.2, 1.1])
+        self.assertTrue(df["valid"].all())
+
+        pd.set_option('display.max_rows', 500)
+        pd.set_option('display.max_columns', 500)
+        pd.set_option('display.width', 1000)
+
+        c.drop()

--- a/matminer/data_retrieval/tests/test_retrieve_MongoDB.py
+++ b/matminer/data_retrieval/tests/test_retrieve_MongoDB.py
@@ -3,17 +3,11 @@ import unittest
 from pymongo import MongoClient
 from pymatgen.util.testing import PymatgenTest
 
-from matminer.data_retrieval.retrieve_MongoDB import \
-    clean_projection, \
-    remove_ints, \
-    MongoDataRetrieval
+from matminer.data_retrieval.retrieve_MongoDB import clean_projection, remove_ints, MongoDataRetrieval
 from matminer.data_retrieval.tests.base import on_ci
-
-import pandas as pd
 
 
 class MongoDataRetrievalTest(PymatgenTest):
-
     def test_cleaned_projection(self):
         p = ["n.o.e", "n.o.e.l", "a.b", "a.b.c", "m", "m.b"]
         result = clean_projection(p)
@@ -27,20 +21,18 @@ class MongoDataRetrievalTest(PymatgenTest):
         self.assertEqual(remove_ints("a.1"), "a")
         self.assertEqual(remove_ints("a.1.x"), "a.x")
 
-    @unittest.skipIf(
-        not on_ci,
-        "MongoDataRetrievalTest configured only to run on CI by default"
-    )
+    @unittest.skipIf(not on_ci, "MongoDataRetrievalTest configured only to run on CI by default")
     def test_get_dataframe(self):
         db = MongoClient("localhost", 27017, username="admin", password="password").test_db
         c = db.test_collection
         docs = [
-            {"some": {"nested": {"result": 14.5}},
-             "other": "notnestedresult",
-             "final": 16.938475 + i,
-             "array": [1.4, 5.6, 11.2, 1.1],
-             "valid": True
-             }
+            {
+                "some": {"nested": {"result": 14.5}},
+                "other": "notnestedresult",
+                "final": 16.938475 + i,
+                "array": [1.4, 5.6, 11.2, 1.1],
+                "valid": True,
+            }
             for i in range(5)
         ]
 
@@ -50,8 +42,7 @@ class MongoDataRetrievalTest(PymatgenTest):
         mdr = MongoDataRetrieval(c)
 
         df = mdr.get_dataframe(
-            criteria={"valid": True},
-            properties=["some.nested.result", "other", "final", "array", "valid"]
+            criteria={"valid": True}, properties=["some.nested.result", "other", "final", "array", "valid"]
         )
 
         self.assertTrue((df["some.nested.result"] == 14.5).all())
@@ -62,9 +53,5 @@ class MongoDataRetrievalTest(PymatgenTest):
 
         self.assertArrayAlmostEqual(df["array"].iloc[0], [1.4, 5.6, 11.2, 1.1])
         self.assertTrue(df["valid"].all())
-
-        pd.set_option('display.max_rows', 500)
-        pd.set_option('display.max_columns', 500)
-        pd.set_option('display.width', 1000)
 
         c.drop()

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,4 @@ if __name__ == "__main__":
         test_suite='matminer',
         tests_require=extras_list,
         scripts=[]
-        # scripts=[os.path.join('scripts', f) for f in os.listdir(os.path.join(module_dir, 'scripts'))]
     )

--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,6 @@ if __name__ == "__main__":
         author_email='anubhavster@gmail.com',
         license='modified BSD',
         packages=find_packages(),
-        package_data={
-            'matminer.datasets': ['*.json'],
-            'matminer.featurizers': ["*/*.yaml"],
-            'matminer.utils.data_files': ['*.cif', '*.csv', '*.tsv', '*.json',
-                                          'magpie_elementdata/*.table',
-                                          'jarvis/*.json', '*.txt']},
         include_package_data=True,
         zip_safe=False,
         install_requires=reqs_list,

--- a/tasks.py
+++ b/tasks.py
@@ -48,7 +48,7 @@ def update_doc(ctx):
 
 @task
 def publish(ctx):
-    ctx.run("python setup.py release")
+    ctx.run("twine upload dist/* --verbose")
 
 
 @task
@@ -72,9 +72,12 @@ def release_github(ctx):
 
 
 @task
-def release(ctx, nosetest=False):
-    if nosetest:
-        ctx.run("nosetests")
+def release(ctx, test=False):
+    if test:
+        ctx.run("python setup.py test")
+    ctx.run("rm -r build dist", warn=True)
+    ctx.run("python setup.py sdist bdist_wheel")
+
     publish(ctx)
     update_doc(ctx)
     release_github(ctx)


### PR DESCRIPTION
- Answers/ Fix #653, as mongo data retrieval is now explicitly tested thus pymongo is needed
- Fix #646 by using non-editable install and editing MANIFEST (MANIFEST + `include_package_data` is now single source of truth, no more `package_data`)
- Update the invoke script (ATTENTION @computron)
  - now uses sdist and bdist_wheel followed by `twine upload` rather than `python setup.py release`