### PR TITLE
Fix pbar when loading datasets not flushing

### DIFF
--- a/matminer/datasets/dataset_retrieval.py
+++ b/matminer/datasets/dataset_retrieval.py
@@ -17,7 +17,7 @@ __author__ = (
 _dataset_dict = None
 
 
-def load_dataset(name, data_home=None, download_if_missing=True):
+def load_dataset(name, data_home=None, download_if_missing=True, pbar=False):
     """
     Loads a dataframe containing the dataset specified with the 'name' field.
 
@@ -33,6 +33,8 @@ def load_dataset(name, data_home=None, download_if_missing=True):
 
         download_if_missing (bool): whether to download the dataset if is not
             found on disk
+
+        pbar (bool): If true, show progress bar for loading dataset.
 
     Returns: (pd.DataFrame,
               tuple -> (pd.DataFrame, pd.DataFrame) if return_lumo = True)
@@ -68,7 +70,7 @@ def load_dataset(name, data_home=None, download_if_missing=True):
         download_if_missing,
     )
 
-    df = load_dataframe_from_json(data_path, pbar=True)
+    df = load_dataframe_from_json(data_path, pbar=pbar)
 
     return df
 

--- a/matminer/utils/io.py
+++ b/matminer/utils/io.py
@@ -3,6 +3,7 @@ This module defines functions for writing and reading matminer related objects
 """
 
 import json
+import sys
 
 import pandas
 from tqdm import tqdm
@@ -131,6 +132,7 @@ def load_dataframe_from_json(filename, pbar=True, decode=True):
         """
         if is_monty_object(obj):
             pbar1.update(1)
+            sys.stderr.flush()
         return obj
 
     # Progress bar for decoding objects
@@ -148,6 +150,7 @@ def load_dataframe_from_json(filename, pbar=True, decode=True):
                 pbar2.total = str(d).count("@class")
             elif is_monty_object(d):
                 pbar2.update(1)
+                sys.stderr.flush()
             return super().process_decoded(d)
 
     if decode:
@@ -159,6 +162,9 @@ def load_dataframe_from_json(filename, pbar=True, decode=True):
 
     with zopen(filename, "rb") as f:
         dataframe_data = json.load(f, cls=decoder, object_hook=hook)
+
+    pbar1.close()
+    pbar2.close()
 
     # if only keys are data, columns, index then orient=split
     if isinstance(dataframe_data, dict):


### PR DESCRIPTION
Sometimes stderr will not get flushed during loading of datasets, leading to (for example, in jupyter nbs) random outputs in later cells from unclosed/unflushed tqdm bars. 

This forcibly flushes and closes tqdm loading bars immediately after decoding inside the load_dataframe_from_json function.