### PR TITLE
Infer compression type in store_dataframe_as_json

### DIFF
--- a/matminer/utils/io.py
+++ b/matminer/utils/io.py
@@ -6,9 +6,9 @@ import json
 import sys
 
 import pandas
-from tqdm import tqdm
 from monty.io import zopen
-from monty.json import MontyEncoder, MontyDecoder
+from monty.json import MontyDecoder, MontyEncoder
+from tqdm import tqdm
 
 
 def store_dataframe_as_json(dataframe, filename, compression=None, orient="split", pbar=True):
@@ -30,11 +30,14 @@ def store_dataframe_as_json(dataframe, filename, compression=None, orient="split
         pbar (bool): If True, shows a progress bar for encoding objects to
             compatible json format (normally the rate-limiting step).
     """
-    if compression not in ["gz", "bz2", None]:
-        raise ValueError("Supported compression formats are 'gz' and 'bz2'.")
+    if filename.lower().endswith((".gz", ".bz2")):
+        compression = filename.split(".")[-1]
 
-    if compression and not filename.lower().endswith(".{}".format(compression)):
-        filename = "{}.{}".format(filename, compression)
+    if compression not in ["gz", "bz2", None]:
+        raise ValueError(f"Supported compression formats are 'gz' and 'bz2', got '{compression}'.")
+
+    if compression and not filename.lower().endswith(f".{compression}"):
+        filename = f"{filename}.{compression}"
 
     write_type = "wb" if compression else "w"
 

--- a/matminer/utils/tests/test_io.py
+++ b/matminer/utils/tests/test_io.py
@@ -1,14 +1,11 @@
+import json
 import os
 import shutil
-import filecmp
 import unittest
-import json
 
 import pandas as pd
-
 from monty.io import zopen
-
-from pymatgen.core import Structure, Lattice
+from pymatgen.core import Lattice, Structure
 from pymatgen.util.testing import PymatgenTest
 
 from matminer.utils.io import load_dataframe_from_json, store_dataframe_as_json
@@ -74,8 +71,8 @@ class IOTest(PymatgenTest):
 
         self.assertDictsAlmostEqual(temp_data, test_data)
 
-        # check writing gzipped json (comparing hashes doesn't work) so have to
-        # compare contents
+        # check writing gzipped json (comparing hashes doesn't work so have to
+        # compare contents)
         temp_file = os.path.join(self.temp_folder, "test_dataframe.json.gz")
         test_file = os.path.join(test_dir, "dataframe.json.gz")
         store_dataframe_as_json(self.df, temp_file, compression="gz")
@@ -91,12 +88,26 @@ class IOTest(PymatgenTest):
 
         self.assertDictsAlmostEqual(temp_data, test_data)
 
-        # check writing bz2 compressed json (comparing hashes doesn't work)
-        # check writing gzipped json (comparing hashes doesn't work) so have to
-        # compare contents
+        # check writing bz2 compressed json
         temp_file = os.path.join(self.temp_folder, "test_dataframe.json.bz2")
         test_file = os.path.join(test_dir, "dataframe.json.bz2")
         store_dataframe_as_json(self.df, temp_file, compression="bz2")
+
+        with zopen(temp_file, "rb") as f:
+            temp_data = json.load(f)
+
+        with zopen(test_file, "rb") as f:
+            test_data = json.load(f)
+
+        temp_data["data"][0][0].pop("@version")
+        test_data["data"][0][0].pop("@version")
+
+        self.assertDictsAlmostEqual(temp_data, test_data)
+
+        # check store_dataframe_as_json can infer compression from file name
+        temp_file = os.path.join(self.temp_folder, "test_dataframe.json.gz")
+        test_file = os.path.join(test_dir, "dataframe.json.gz")
+        store_dataframe_as_json(self.df, temp_file)
 
         with zopen(temp_file, "rb") as f:
             temp_data = json.load(f)


### PR DESCRIPTION
Closes #741.

I added a new test case for this feature. Could also include a test for this functionality in one of the existing cases to avoid increasing CI run time if you prefer.