### PR TITLE
Add ability to customize `BaseFeaturizer` `pbar` by passing dict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,5 @@
 exclude: ^(docs|.*test_files|cmd_line|dev_scripts)
 
-default_language_version:
-  python: python3
-
 ci:
   autoupdate_schedule: monthly
   skip: [flake8, mypy, pylint]
@@ -13,12 +10,6 @@ repos:
     rev: v1.4
     hooks:
       - id: autoflake
-        args:
-          - --in-place
-          - --remove-unused-variables
-          - --remove-all-unused-imports
-          - --expand-star-imports
-          - --ignore-init-module-imports
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.32.0
@@ -38,7 +29,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-        args: ["--profile", "black"]
+        args: [--profile, black]
 
   - repo: https://github.com/psf/black
     rev: 22.3.0
@@ -62,9 +53,5 @@ repos:
         entry: pylint
         language: python
         types: [python]
-        args:
-          [
-            "-sn",
-            "--rcfile=pylintrc",
-          ]
+        args: [-sn, --rcfile=pylintrc]
         additional_dependencies: [pylint]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,18 +7,18 @@ ci:
 repos:
 
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v1.7.7
     hooks:
       - id: autoflake
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v3.2.2
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-yaml
         exclude: pymatgen/analysis/vesta_cutoffs.yaml
@@ -32,17 +32,17 @@ repos:
         args: [--profile, black]
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.991
     hooks:
       - id: mypy
 

--- a/docs/_sources/installation.rst.txt
+++ b/docs/_sources/installation.rst.txt
@@ -55,4 +55,4 @@ Tips
 
     - For example, installing pymatgen on a Windows platform is easiest with Anaconda via ``conda install -c conda-forge pymatgen``.
 
-* If you still have trouble, open up a a ticket on our `forum <https://discuss.matsci.org/c/matminer>`_  describing your problem in full (including your system specifications, Python version information, and input/output log). There is a good likelihood that someone else is running into the same issue, and by posting it on the forum we can help make the documentation clearer and smoother.
+* If you still have trouble, open up a ticket on our `forum <https://discuss.matsci.org/c/matminer>`_  describing your problem in full (including your system specifications, Python version information, and input/output log). There is a good likelihood that someone else is running into the same issue, and by posting it on the forum we can help make the documentation clearer and smoother.

--- a/docs_rst/installation.rst
+++ b/docs_rst/installation.rst
@@ -55,4 +55,4 @@ Tips
 
     - For example, installing pymatgen on a Windows platform is easiest with Anaconda via ``conda install -c conda-forge pymatgen``.
 
-* If you still have trouble, open up a a ticket on our `forum <https://discuss.matsci.org/c/matminer>`_  describing your problem in full (including your system specifications, Python version information, and input/output log). There is a good likelihood that someone else is running into the same issue, and by posting it on the forum we can help make the documentation clearer and smoother.
+* If you still have trouble, open up a ticket on our `forum <https://discuss.matsci.org/c/matminer>`_  describing your problem in full (including your system specifications, Python version information, and input/output log). There is a good likelihood that someone else is running into the same issue, and by posting it on the forum we can help make the documentation clearer and smoother.

--- a/matminer/datasets/tests/test_datasets.py
+++ b/matminer/datasets/tests/test_datasets.py
@@ -114,14 +114,14 @@ class MatminerDatasetsTest(DataSetsTest):
         ]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
+            self.assertIsInstance(df["structure"][0], Structure)
             tensor_headers = [
                 "compliance_tensor",
                 "elastic_tensor",
                 "elastic_tensor_original",
             ]
             for c in tensor_headers:
-                self.assertEqual(type(df[c][0]), np.ndarray)
+                self.assertIsInstance(df[c][0], np.ndarray)
 
         self.universal_dataset_check(
             "elastic_tensor_2015",
@@ -146,8 +146,8 @@ class MatminerDatasetsTest(DataSetsTest):
         numeric_headers = ["nsites", "space_group", "volume", "eij_max"]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
-            self.assertEqual(type(df["piezoelectric_tensor"][0]), np.ndarray)
+            self.assertIsInstance(df["structure"][0], Structure)
+            self.assertIsInstance(df["piezoelectric_tensor"][0], np.ndarray)
 
         self.universal_dataset_check(
             "piezoelectric_tensor",
@@ -181,7 +181,7 @@ class MatminerDatasetsTest(DataSetsTest):
         bool_headers = ["pot_ferroelectric"]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
+            self.assertIsInstance(df["structure"][0], Structure)
 
         self.universal_dataset_check(
             "dielectric_constant",
@@ -202,7 +202,7 @@ class MatminerDatasetsTest(DataSetsTest):
         ]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
+            self.assertIsInstance(df["structure"][0], Structure)
 
         self.universal_dataset_check("flla", object_headers, numeric_headers, test_func=_unique_tests)
 
@@ -222,7 +222,7 @@ class MatminerDatasetsTest(DataSetsTest):
         bool_headers = ["gap is direct"]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
+            self.assertIsInstance(df["structure"][0], Structure)
 
         self.universal_dataset_check(
             "castelli_perovskites",
@@ -238,7 +238,7 @@ class MatminerDatasetsTest(DataSetsTest):
         numeric_headers = ["pf_n", "pf_p", "s_n", "s_p", "m_n", "m_p"]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
+            self.assertIsInstance(df["structure"][0], Structure)
 
         self.universal_dataset_check("boltztrap_mp", object_headers, numeric_headers, test_func=_unique_tests)
 
@@ -248,7 +248,7 @@ class MatminerDatasetsTest(DataSetsTest):
         numeric_headers = ["eps_electronic", "eps_total", "last phdos peak"]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
+            self.assertIsInstance(df["structure"][0], Structure)
 
         self.universal_dataset_check(
             "phonon_dielectric_mp",
@@ -304,7 +304,7 @@ class MatminerDatasetsTest(DataSetsTest):
         ]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
+            self.assertIsInstance(df["structure"][0], Structure)
 
         self.universal_dataset_check("mp_all_20181018", object_headers, numeric_headers, test_func=_unique_tests)
 
@@ -429,8 +429,8 @@ class MatminerDatasetsTest(DataSetsTest):
         ]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
-            self.assertEqual(type(df["composition"][0]), Composition)
+            self.assertIsInstance(df["structure"][0], Structure)
+            self.assertIsInstance(df["composition"][0], Composition)
 
         self.universal_dataset_check(
             "jarvis_ml_dft_training",
@@ -463,8 +463,8 @@ class MatminerDatasetsTest(DataSetsTest):
         ]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
-            self.assertEqual(type(df["composition"][0]), Composition)
+            self.assertIsInstance(df["structure"][0], Structure)
+            self.assertIsInstance(df["composition"][0], Composition)
 
         self.universal_dataset_check("jarvis_dft_3d", object_headers, numeric_headers, test_func=_unique_tests)
 
@@ -491,8 +491,8 @@ class MatminerDatasetsTest(DataSetsTest):
         ]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
-            self.assertEqual(type(df["composition"][0]), Composition)
+            self.assertIsInstance(df["structure"][0], Structure)
+            self.assertIsInstance(df["composition"][0], Composition)
 
         self.universal_dataset_check("jarvis_dft_2d", object_headers, numeric_headers, test_func=_unique_tests)
 
@@ -558,8 +558,8 @@ class MatminerDatasetsTest(DataSetsTest):
         bool_headers = ["suspect_value"]
 
         def _unique_tests(df):
-            self.assertEqual(type(df["structure"][0]), Structure)
-            self.assertEqual(type(df["composition"][0]), Composition)
+            self.assertIsInstance(df["structure"][0], Structure)
+            self.assertIsInstance(df["composition"][0], Composition)
             self.assertTrue(isinstance(df["brgoch_feats"][0], dict))
 
         self.universal_dataset_check(

--- a/matminer/featurizers/base.py
+++ b/matminer/featurizers/base.py
@@ -35,7 +35,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin, ABC):
     a featurizer that returns the partial radial distribution function
     may need to know which elements are present in a dataset.
 
-    You can can also use the `precheck` and `precheck_dataframe` methods to
+    You can also use the `precheck` and `precheck_dataframe` methods to
     ensure a featurizer is in scope for a given sample (or dataset) before
     featurizing.
 
@@ -438,7 +438,7 @@ class BaseFeaturizer(BaseEstimator, TransformerMixin, ABC):
         # Add a progress bar
         if pbar:
             # list() required, tqdm has issues with memory if generator given
-            entries = tqdm(list(entries), desc=self.__class__.__name__)
+            entries = tqdm(list(entries), desc=self.__class__.__name__, **(pbar if isinstance(pbar, dict) else {}))
 
         # Run the actual featurization
         if self.n_jobs == 1:

--- a/matminer/featurizers/site/rdf.py
+++ b/matminer/featurizers/site/rdf.py
@@ -209,10 +209,10 @@ class GeneralizedRadialDistributionFunction(BaseFeaturizer):
         features output from this mode will be vectors with length n_bins.
 
     2. pairwise GRDF: (advanced users) - n_bins x n_sites matrix
-        In this mode, GRDFs are are still computed around a central site, but
+        In this mode, GRDFs are still computed around a central site, but
         only one other site (and their translational equivalents) are used to
         compute a GRDF (e.g. site 1 with site 2 and the translational
-        equivalents of site 2). This results in a a n_sites x n_bins matrix of
+        equivalents of site 2). This results in a n_sites x n_bins matrix of
         features. Requires `fit` for determining the max number of sites for
 
     The GRDF is a generalization of the partial radial distribution function

--- a/matminer/featurizers/structure/sites.py
+++ b/matminer/featurizers/structure/sites.py
@@ -55,7 +55,7 @@ class SiteStatsFingerprint(BaseFeaturizer):
         """
 
         self.site_featurizer = site_featurizer
-        self.stats = tuple([stats]) if type(stats) == str else stats
+        self.stats = tuple([stats]) if isinstance(stats, str) else stats
         if self.stats and "_mode" in "".join(self.stats):
             nmodes = 0
             for stat in self.stats:

--- a/matminer/featurizers/structure/sites.py
+++ b/matminer/featurizers/structure/sites.py
@@ -25,7 +25,7 @@ class SiteStatsFingerprint(BaseFeaturizer):
     This featurizer first uses a site featurizer class (see site.py for
     options) to compute features of each site in a structure, and then computes
     features of the entire structure by measuring statistics of each attribute.
-    Can optionally compute the the statistics of only sites with certain ranges
+    Can optionally compute the statistics of only sites with certain ranges
     of oxidation states (e.g., only anions).
 
     Features:

--- a/matminer/featurizers/utils/stats.py
+++ b/matminer/featurizers/utils/stats.py
@@ -19,7 +19,7 @@ class PropertyStats:
         PropertyStats.calc_stat(x, 'mean', weights=[0, 0, 1]) # Result is 3
 
     Some of the statistics functions take options (e.g., Holder means). You can
-    pass them to the the statistics functions by adding them after the name and
+    pass them to the statistics functions by adding them after the name and
     two colons. For example, the 0th Holder mean would be::
 
         PropertyStats.calc_stat(x, 'holder_mean::0')

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,10 +11,10 @@ upload_docs = upload_docs --upload-dir=docs/_build/html
 release = register sdist upload
 
 [pycodestyle]
-count = True
+count = true
 ignore = E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505,E741,W605,W293,W291,W292,E203,E231
 max-line-length = 120
-statistics = True
+statistics = true
 exclude=docs_rst/*.py
 
 [flake8]
@@ -43,7 +43,14 @@ exclude_lines =
     @deprecated
 
 [mypy]
-ignore_missing_imports = True
+ignore_missing_imports = true
 
 [isort]
 profile = black
+
+[autoflake]
+in-place = true
+remove-unused-variables = true
+remove-all-unused-imports = true
+expand-star-imports = true
+ignore-init-module-imports = true


### PR DESCRIPTION
I would like to set

```py
tqdm(lst, position=0, leave=True)
```

so that slurm log files aren't filled with 1000s of `pbar` lines but just the last iteration's line showing the total wall time.

With this PR, that'll be possible by passing

```py
df_features = featurizer.featurize_dataframe(
    df, input_col, pbar=dict(position=0, leave=True)
)
```

Old logs

```txt
...
MultipleFeaturizer: 100%|█████████▉| 12859/12874 [1:27:44<00:07,  2.14it/s]
MultipleFeaturizer: 100%|█████████▉| 12860/12874 [1:27:44<00:06,  2.04it/s]
MultipleFeaturizer: 100%|█████████▉| 12861/12874 [1:27:45<00:06,  2.00it/s]
MultipleFeaturizer: 100%|█████████▉| 12862/12874 [1:27:45<00:06,  1.97it/s]
MultipleFeaturizer: 100%|█████████▉| 12863/12874 [1:27:46<00:05,  1.95it/s]
MultipleFeaturizer: 100%|█████████▉| 12864/12874 [1:27:46<00:05,  1.94it/s]
MultipleFeaturizer: 100%|█████████▉| 12865/12874 [1:27:47<00:04,  1.93it/s]
MultipleFeaturizer: 100%|█████████▉| 12866/12874 [1:27:47<00:04,  1.92it/s]
MultipleFeaturizer: 100%|█████████▉| 12867/12874 [1:27:48<00:03,  1.98it/s]
MultipleFeaturizer: 100%|█████████▉| 12868/12874 [1:27:48<00:03,  1.95it/s]
MultipleFeaturizer: 100%|█████████▉| 12869/12874 [1:27:49<00:02,  2.25it/s]
MultipleFeaturizer: 100%|█████████▉| 12870/12874 [1:27:52<00:05,  1.35s/it]
MultipleFeaturizer: 100%|█████████▉| 12871/12874 [1:27:53<00:03,  1.03s/it]
MultipleFeaturizer: 100%|█████████▉| 12872/12874 [1:27:53<00:01,  1.26it/s]
MultipleFeaturizer: 100%|█████████▉| 12873/12874 [1:27:53<00:00,  1.59it/s]
MultipleFeaturizer: 100%|██████████| 12874/12874 [1:27:53<00:00,  1.77it/s]
MultipleFeaturizer: 100%|██████████| 12874/12874 [1:27:53<00:00,  2.44it/s]
```

New logs

```txt
MultipleFeaturizer: 100%|██████████| 12874/12874 [1:27:53<00:00,  2.44it/s]
```