### PR TITLE
Assign `__init__` arg to instance attribute to fix sklearn base `__repr__`

### DIFF
--- a/matminer/featurizers/structure/order.py
+++ b/matminer/featurizers/structure/order.py
@@ -29,6 +29,7 @@ class DensityFeatures(BaseFeaturizer):
             desired_features: [str] - choose from "density", "vpa",
                 "packing fraction"
         """
+        self.desired_features = desired_features
         self.features = ["density", "vpa", "packing fraction"] if not desired_features else desired_features
 
     def precheck(self, s: Structure) -> bool:

--- a/matminer/featurizers/structure/symmetry.py
+++ b/matminer/featurizers/structure/symmetry.py
@@ -32,6 +32,7 @@ class GlobalSymmetryFeatures(BaseFeaturizer):
     all_features = ["spacegroup_num", "crystal_system", "crystal_system_int", "is_centrosymmetric", "n_symmetry_ops"]
 
     def __init__(self, desired_features=None):
+        self.desired_features = desired_features
         self.features = desired_features if desired_features else self.all_features
 
     def featurize(self, s):


### PR DESCRIPTION
## Summary

Closes #864.

Simply turns the `desired_features` arg to the `__init__` of `DensityFeatures` and `GlobalSymmetry` into an instance attribute, which prevents a crash when calling `__repr__` for the class (something that happens within featurization progress bars). This is because `__repr__` is being inherited from the underlying `sklearn` class that provides introspection into the `__init__` arguments of the featurizer.

This PR fixes it in the places I have run into personally, but more may be lurking around. One general fix would be to simply define a custom `__repr__` for the base `matminer` featurizer to avoid using the `sklearn` one.