### PR TITLE
Optimize `BandCenter` and `IntersticeDistribution` featurizers

### DIFF
--- a/matminer/featurizers/composition/element.py
+++ b/matminer/featurizers/composition/element.py
@@ -207,6 +207,9 @@ class BandCenter(BaseFeaturizer):
         - Band center
     """
 
+    magpie_data = MagpieData()
+    deml_data = DemlData()
+
     def featurize(self, comp):
         """
         (Rough) estimation of absolution position of band center using
@@ -222,8 +225,8 @@ class BandCenter(BaseFeaturizer):
         gmean = 1.0
         sumamt = sum(comp.get_el_amt_dict().values())
         for el, amt in comp.get_el_amt_dict().items():
-            first_ioniz = DemlData().get_elemental_property(Element(el), "first_ioniz") / 1000
-            elec_aff = MagpieData().get_elemental_property(Element(el), "ElectronAffinity")
+            first_ioniz = self.deml_data.get_elemental_property(Element(el), "first_ioniz") / 1000
+            elec_aff = self.magpie_data.get_elemental_property(Element(el), "ElectronAffinity")
             gmean *= (0.5 * (first_ioniz + elec_aff) / 96.48) ** (amt / sumamt)
         return [gmean]
 

--- a/matminer/featurizers/site/misc.py
+++ b/matminer/featurizers/site/misc.py
@@ -59,6 +59,7 @@ class IntersticeDistribution(BaseFeaturizer):
             raise ValueError("interstice_types only support sub-list of " "['dist', 'area', 'vol']")
         self.stats = ["mean", "std_dev", "minimum", "maximum"] if stats is None else stats
         self.radius_type = radius_type
+        self.data_source = MagpieData()
 
     def featurize(self, struct, idx):
         """
@@ -78,9 +79,9 @@ class IntersticeDistribution(BaseFeaturizer):
         nn_coords = np.array([nn["site"].coords for nn in n_w])
 
         # Get center atom's radius and its nearest neighbors' radii
-        center_r = MagpieData().get_elemental_properties([struct[idx].specie], self.radius_type)[0] / 100
+        center_r = self.data_source.get_elemental_properties([struct[idx].specie], self.radius_type)[0] / 100
         nn_els = [nn["site"].specie for nn in n_w]
-        nn_rs = np.array(MagpieData().get_elemental_properties(nn_els, self.radius_type)) / 100
+        nn_rs = np.array(self.data_source.get_elemental_properties(nn_els, self.radius_type)) / 100
 
         # Get indices of atoms forming the simplices of convex hull
         convex_hull_simplices = ConvexHull(nn_coords).simplices


### PR DESCRIPTION
This PR simply initialises various data sources at the class or instance level, rather than in the featurizer loop, which was causing the data sources to be loaded from disk for every featurization leading to serious performance issues (as one might expect).

`BandCenter`, for example, is now 5 orders of magnitude faster on my machine.

I couldn't spot any other featurizers that have this issue though my search wasn't exhaustive.