### PR TITLE
Skip the thermo tests rather than crash if MP API is missing

### DIFF
--- a/matminer/featurizers/composition/tests/test_thermo.py
+++ b/matminer/featurizers/composition/tests/test_thermo.py
@@ -9,14 +9,23 @@ from matminer.featurizers.composition.thermo import CohesiveEnergy, CohesiveEner
 
 class ThermoFeaturesTest(CompositionFeaturesTest):
     def test_cohesive_energy(self):
-        mpr = MPRester()
+        try:
+            mpr = MPRester()
+        except ValueError:
+            raise SkipTest("Materials Project API key not set; Skipping cohesive energy test")
+
         if not mpr.api_key:
             raise SkipTest("Materials Project API key not set; Skipping cohesive energy test")
+
         df_cohesive_energy = CohesiveEnergy().featurize_dataframe(self.df, col_id="composition")
         self.assertAlmostEqual(df_cohesive_energy["cohesive energy"][0], 5.179358342, 2)
 
     def test_cohesive_energy_mp(self):
-        mpr = MPRester()
+        try:
+            mpr = MPRester()
+        except ValueError:
+            raise SkipTest("Materials Project API key not set; Skipping cohesive energy test")
+
         if not mpr.api_key:
             raise SkipTest("Materials Project API key not set; Skipping cohesive energy test")
         ce = CohesiveEnergyMP()


### PR DESCRIPTION
For the current released pymatgen version, creating an `MPRester` without an API key will raise a `ValueError`. This is fixed in the main pymatgen branch, but for now, this PR allows the tests to skip when no MP API key is present (as intended by the original code).

This should fix the test errors seen in #892 for @gbrunin.