### PR TITLE
Defer `MPRester` import to allow it to act more like an optional dep

### DIFF
--- a/matminer/featurizers/composition/thermo.py
+++ b/matminer/featurizers/composition/thermo.py
@@ -2,7 +2,6 @@
 Composition featurizers for thermodynamic properties.
 """
 
-from pymatgen.ext.matproj import MPRester
 
 from matminer.featurizers.base import BaseFeaturizer
 from matminer.utils.data import CohesiveEnergyData
@@ -40,6 +39,8 @@ class CohesiveEnergy(BaseFeaturizer):
         formation_energy_per_atom = formation_energy_per_atom or None
 
         if not formation_energy_per_atom:
+            from pymatgen.ext.matproj import MPRester
+
             # Get formation energy of most stable structure from MP
             if self.mapi_key:
                 struct_lst = MPRester(self.mapi_key).get_data(comp.reduced_formula)
@@ -98,6 +99,7 @@ class CohesiveEnergyMP(BaseFeaturizer):
         Args:
             comp: (str) compound composition, eg: "NaCl"
         """
+        from pymatgen.ext.matproj import MPRester
 
         # Get formation energy of most stable structure from MP
         with MPRester(self.mapi_key) if self.mapi_key else MPRester() as mpr:

--- a/matminer/featurizers/conversions.py
+++ b/matminer/featurizers/conversions.py
@@ -12,7 +12,6 @@ import json
 from monty.json import MontyDecoder
 from pymatgen.core.composition import Composition
 from pymatgen.core.structure import IStructure
-from pymatgen.ext.matproj import MPRester
 from pymatgen.io.ase import AseAtomsAdaptor
 
 from matminer.featurizers.base import BaseFeaturizer
@@ -566,6 +565,9 @@ class CompositionToStructureFromMP(ConversionFeaturizer):
     """
 
     def __init__(self, target_col_id="structure", overwrite_data=False, mapi_key=None):
+
+        from pymatgen.ext.matproj import MPRester
+
         super().__init__(target_col_id, overwrite_data)
         if mapi_key:
             self.mpr = MPRester(mapi_key)


### PR DESCRIPTION
There are some awkward version conflicts between pymatgen, mp_api and emmet, and as this package now tries to be agnostic to `MPRester` version, imports can error for some subset of versions. This PR defers the import of `MPRester` so that it only errors in cases where the user is trying to use it.