### PR TITLE
remove pandas~=1.5 pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         install_requires=[
             "numpy>=1.20.1",
             "requests",
-            "pandas~=1.5",
+            "pandas",
             "tqdm",
             "pymongo",
             "future",


### PR DESCRIPTION
@ml-evs we would like to upgrade to pandas 2 for MP. Would it be possible to remove the `pandas` requirement in matminer?
