### PR TITLE
Prevent warning in fingerprint.py during yaml.safe_load

### DIFF
--- a/matminer/featurizers/site/fingerprint.py
+++ b/matminer/featurizers/site/fingerprint.py
@@ -873,7 +873,7 @@ def load_cn_motif_op_params():
     with open(
         os.path.join(os.path.dirname(pymatgen.analysis.local_env.__file__), "cn_opt_params.yaml"),
     ) as f:
-        return yaml.safe_load(f)
+        return yaml.YAML(typ="safe", pure=True).load(f)
 
 
 def load_cn_target_motif_op():
@@ -884,4 +884,4 @@ def load_cn_target_motif_op():
         (dict)
     """
     with open(os.path.join(os.path.dirname(__file__), "cn_target_motif_op.yaml")) as f:
-        return yaml.safe_load(f)
+        return yaml.YAML(typ="safe", pure=True).load(f)


### PR DESCRIPTION
ruamel.yaml.safe_load is deprecated:
https://sourceforge.net/p/ruamel-yaml/code/ci/0.17.32/tree/main.py#l1110