### PR TITLE
Added missing `impute_nan` for `WenAlloys` and removed unnecessary warning

### DIFF
--- a/matminer/featurizers/composition/alloy.py
+++ b/matminer/featurizers/composition/alloy.py
@@ -719,7 +719,7 @@ class WenAlloys(BaseFeaturizer):
         atomic_fraction = self.compute_atomic_fraction(elements, comp)
         yang_delta = self.yss.compute_delta(comp)
         yang_omega = self.yss.compute_omega(comp)
-        ape = AtomicPackingEfficiency().compute_simultaneous_packing_efficiency(comp)[0]
+        ape = AtomicPackingEfficiency(impute_nan=self.impute_nan).compute_simultaneous_packing_efficiency(comp)[0]
         radii_local_mismatch = self.compute_local_mismatch(miracle_radius_stats["array"], fractions)
         radii_gamma = self.compute_gamma_radii(miracle_radius_stats)
         S_config = self.compute_configuration_entropy(fractions)

--- a/matminer/featurizers/composition/composite.py
+++ b/matminer/featurizers/composition/composite.py
@@ -55,8 +55,6 @@ class ElementProperty(BaseFeaturizer):
 
     def __init__(self, data_source, features, stats, impute_nan=False):
         self.impute_nan = impute_nan
-        if not self.impute_nan:
-            warnings.warn(f"{self.__class__.__name__}(impute_nan=False):\n" + IMPUTE_NAN_WARNING)
         if data_source == "pymatgen":
             self.data_source = PymatgenData(impute_nan=self.impute_nan)
         elif data_source == "magpie":

--- a/matminer/featurizers/composition/packing.py
+++ b/matminer/featurizers/composition/packing.py
@@ -82,7 +82,7 @@ class AtomicPackingEfficiency(BaseFeaturizer):
         self.impute_nan = impute_nan
         if not self.impute_nan:
             warnings.warn(f"{self.__class__.__name__}(impute_nan=False):\n" + IMPUTE_NAN_WARNING)
-        self._data_source = MagpieData(impute_nan=impute_nan)
+        self._data_source = MagpieData(impute_nan=self.impute_nan)
 
         # Lookup table of ideal radius ratios
         self.ideal_ratio = dict(


### PR DESCRIPTION
## Summary

This fixes 2 small things: 
- A warning about NaN imputation was written in case ElementProperty was initialiazed with impute_nan=False, even though the data source could be itself initialized with impute_nan=True. The warning is removed, since the imputation is only happening at the level of the data source.
- I missed an imputation in WenAlloys featurizer.

I'm make some tests now to decide whether the default of impute_nan should be switched to True. 