### PR TITLE
Disable release creation workflow on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,8 @@ jobs:
       - test
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.PAT }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PAT: ${{ secrets.PAT }}
     steps:
       - uses: rymndhng/release-on-push-action@v0.25.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,9 +91,9 @@ jobs:
     needs:
       - test
     runs-on: ubuntu-latest
+    if: github.repository == 'hackingmaterials/matminer'
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PAT: ${{ secrets.PAT }}
+      GITHUB_TOKEN: ${{ secrets.PAT }}
     steps:
       - uses: rymndhng/release-on-push-action@v0.25.0
         with:


### PR DESCRIPTION
I kept having this issue with our fork:
https://github.com/Matgenix/matminer/actions/runs/10141810059/job/28039988779

which I fixed by setting GITHUB_TOKEN and PAT explicitly. I'm not super familiar with the test.yml file so maybe there's a better fix (or maybe it should not be fixed), let me know. 