### PR TITLE
Disable test PyPI build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,15 +78,6 @@ jobs:
         python${{ matrix.python-version }} -m pip install --upgrade pip build setuptools setuptools_scm wheel
         python${{ matrix.python-version }} -m build
 
-    - name: Publish distribution 📦s to Test PyPI
-      if: matrix.python-version == 3.9 && github.repository == 'hackingmaterials/matminer'
-      uses: pypa/gh-action-pypi-publish@release/v1.5
-      with:
-        skip_existing: true
-        repository_url: https://test.pypi.org/legacy/
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
-
   auto-gen-release:
     needs:
       - test


### PR DESCRIPTION
The credentials and mechanism used for the test PyPI workflow are now defunct. I'd rather remove it than take the maintenance burden. The package build test is more robust.