### PR TITLE
Support NumPy 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Run tests
       run: |
-        python${{ matrix.python-version }} -m pytest --cov=matminer matminer --durations=0 --timeout=360
+        python${{ matrix.python-version }} -m pytest --cov=matminer matminer --durations=20 --timeout=360
 
     - name: Build package
       if: matrix.python-version == 3.9

--- a/matminer/__init__.py
+++ b/matminer/__init__.py
@@ -1,9 +1,9 @@
 """data mining materials properties"""
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = get_distribution("matminer").version
-except DistributionNotFound:  # pragma: no cover
+    __version__ = version("matminer")
+except PackageNotFoundError:  # pragma: no cover
     # package is not installed
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-     # pin NumPy version used in the build
-     "numpy>=1.20.1, <2",
+     "numpy>=2.0.0",
      "setuptools>=43.0.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
-     "numpy>=2.0.0",
      "setuptools>=43.0.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         include_package_data=True,
         zip_safe=False,
         install_requires=[
-            "numpy >= 1.23, < 2",
+            "numpy >= 1.23",
             "requests ~= 2.31",
             "pandas >= 1.5, < 3",
             "tqdm ~= 4.66",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         include_package_data=True,
         zip_safe=False,
         install_requires=[
-            "numpy >= 1.23",
+            "numpy >= 2",
             "requests ~= 2.31",
             "pandas >= 1.5, < 3",
             "tqdm ~= 4.66",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         include_package_data=True,
         zip_safe=False,
         install_requires=[
-            "numpy >= 2",
+            "numpy >= 1.23, < 2",
             "requests ~= 2.31",
             "pandas >= 1.5, < 3",
             "tqdm ~= 4.66",


### PR DESCRIPTION
### Summary

- Support NumPy 2
- [x] Test both [NumPy 1](https://github.com/hackingmaterials/matminer/pull/949/checks?check_run_id=31133704592) and [NumPy 2](https://github.com/hackingmaterials/matminer/pull/949/checks?check_run_id=31133500186)
- `pytest` workflow only show top 20 duration instead of all, otherwise the log page is too long to navigate through

### Future PR
- Completely migrate to `pyproject.toml`
