### PR TITLE
Fix WenAlloys.compute_gamma_radii to match documented formula (#952)

### DIFF
--- a/src/matminer/featurizers/composition/alloy.py
+++ b/src/matminer/featurizers/composition/alloy.py
@@ -834,8 +834,8 @@ class WenAlloys(BaseFeaturizer):
         mrmin = miracle_radius_stats["min"]
         mrmax = miracle_radius_stats["max"]
 
-        numerator = 1 - np.sqrt((mrmean * mrmin + mrmin**2) / (mrmean + mrmin) ** 2)
-        denominator = 1 - np.sqrt((mrmean * mrmax + mrmax**2) / (mrmean + mrmax) ** 2)
+        numerator = 1 - np.sqrt(((mrmean + mrmin) ** 2 - mrmean**2) / (mrmean + mrmin) ** 2)
+        denominator = 1 - np.sqrt(((mrmean + mrmax) ** 2 - mrmean**2) / (mrmean + mrmax) ** 2)
         return numerator / denominator
 
     @staticmethod

--- a/tests/featurizers/composition/test_alloy.py
+++ b/tests/featurizers/composition/test_alloy.py
@@ -252,7 +252,7 @@ class AlloyFeaturizersTest(CompositionFeaturesTest):
             "Lambda entropy": -12.084431980055149,
             "Mean cohesive energy": 4.382084353941212,
             "Mixing enthalpy": 3.6650695863166347,
-            "Radii gamma": 1.4183511064895242,
+            "Radii gamma": 1.8548430634198114,
             "Radii local mismatch": 0.7953797741513383,
             "Shear modulus delta": 0.1794147729878139,
             "Shear modulus local mismatch": 3.192861083726266,
@@ -321,7 +321,7 @@ class AlloyFeaturizersTest(CompositionFeaturesTest):
             "Lambda entropy": -12.084431980055149,
             "Mean cohesive energy": 4.382084353941212,
             "Mixing enthalpy": 3.6650695863166347,
-            "Radii gamma": 1.4183511064895242,
+            "Radii gamma": 1.8548430634198114,
             "Radii local mismatch": 0.7953797741513383,
             "Shear modulus delta": 0.1794147729878139,
             "Shear modulus local mismatch": 3.192861083726266,
@@ -373,7 +373,7 @@ class AlloyFeaturizersTest(CompositionFeaturesTest):
             "Lambda entropy": -0.014796268010071023,
             "Mean cohesive energy": 3.0675,
             "Mixing enthalpy": 10.652682648401827,
-            "Radii gamma": 1.9699221262511677,
+            "Radii gamma": 3.3935618188826431,
             "Radii local mismatch": 23.0625,
             "Shear modulus delta": 0.37931021448197916,
             "Shear modulus local mismatch": 7.13935787671233,
@@ -401,6 +401,23 @@ class AlloyFeaturizersTest(CompositionFeaturesTest):
         self.assertTupleEqual(df.shape, (2, 26))
         self.assertAlmostEqual(df["Configuration entropy"].iloc[0], -0.008959, places=5)
         self.assertAlmostEqual(df["Configuration entropy"].iloc[1], -0.009039, places=5)
+
+    def test_wen_alloys_gamma_radii(self):
+        # Gamma is the ratio of the solid angles of the smallest and largest
+        # atoms, omega_S / omega_L, with
+        # omega = 1 - sqrt(((r + r_bar)**2 - r_bar**2) / (r + r_bar)**2),
+        # per Wang et al., Scripta Mater. 94 (2015) 28-31
+        # (doi:10.1016/j.scriptamat.2014.09.010).
+        # https://github.com/hackingmaterials/matminer/issues/952
+        r_bar, r_min, r_max = 140.0, 120.0, 160.0
+
+        def omega(r):
+            return 1 - np.sqrt(((r_bar + r) ** 2 - r_bar**2) / (r_bar + r) ** 2)
+
+        stats = {"mean": r_bar, "min": r_min, "max": r_max}
+        expected = omega(r_min) / omega(r_max)
+        self.assertAlmostEqual(WenAlloys.compute_gamma_radii(stats), expected, places=12)
+        self.assertAlmostEqual(WenAlloys.compute_gamma_radii(stats), 1.3615503496919474, places=12)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #952.

`WenAlloys.compute_gamma_radii` implements the atomic-packing parameter γ = ω_S / ω_L (solid angles of the smallest and largest atoms) from Wang et al., *Scripta Materialia* **94** (2015) 28–31 ([doi:10.1016/j.scriptamat.2014.09.010](https://doi.org/10.1016/j.scriptamat.2014.09.010)), where

```
omega = 1 - sqrt( ((r + r_bar)^2 - r_bar^2) / (r + r_bar)^2 )
```

The implementation expanded the numerator inside the square root incorrectly:

```python
# before
numerator   = 1 - np.sqrt((mrmean * mrmin + mrmin**2) / (mrmean + mrmin) ** 2)
denominator = 1 - np.sqrt((mrmean * mrmax + mrmax**2) / (mrmean + mrmax) ** 2)
```

`(r + r_bar)^2 - r_bar^2` expands to `2*r_bar*r + r^2`, but the code used `r_bar*r + r^2` — i.e. it dropped one `r_bar*r` term. This made the code disagree with **both its own docstring and the source paper**. (Reported by @KwamiAldo in #952.)

## Fix

```python
# after
numerator   = 1 - np.sqrt(((mrmean + mrmin) ** 2 - mrmean**2) / (mrmean + mrmin) ** 2)
denominator = 1 - np.sqrt(((mrmean + mrmax) ** 2 - mrmean**2) / (mrmean + mrmax) ** 2)
```

The docstring already documented the correct (paper) formula, so this only changes the implementation to match it.

## Impact

This changes the value of the `"Radii gamma"` feature. For example, with mean/min/max Miracle radii of 140/120/160 pm, γ changes from `1.189` to `1.362` — which straddles the commonly used γ ≈ 1.175 solid-solution vs. intermetallic threshold, so the correction can affect downstream phase-stability screening. The pinned `"Radii gamma"` values in `test_WenAlloys` are updated accordingly.

## Test plan

- Added `test_wen_alloys_gamma_radii`, a focused regression test that checks `compute_gamma_radii` against the closed-form ω_S/ω_L expression (and a hard-coded analytic value). It **fails on `main`** (old formula gives `1.1888…`) and passes here.
- Updated the three affected `"Radii gamma"` values in `test_WenAlloys` to the corrected outputs.
- `pytest tests/featurizers/composition/test_alloy.py` passes (5 passed).
- `black --check` (line-length 120) clean on the changed files; no new `flake8` issues introduced.

## Note

This PR intentionally fixes **only** `compute_gamma_radii`. The related #962 also flags the configuration-entropy sign and the mixing-enthalpy `abs()`; I've kept those out of scope here so this change stays minimal and easy to review. (For what it's worth, the "Yang omega is affected" claim in #962 does not appear to hold — `YangSolidSolution.compute_omega` wraps the result in `abs()`, so the entropy sign cancels there — but happy to follow up separately on the entropy/enthalpy features if you'd like.)
