### PR TITLE
fix typo in matminer.featurizers.structure.SiteStatsFingerprint

### DIFF
--- a/src/matminer/featurizers/structure/sites.py
+++ b/src/matminer/featurizers/structure/sites.py
@@ -93,7 +93,7 @@ class SiteStatsFingerprint(BaseFeaturizer):
         vals = [[] for t in self._site_labels]
         for i, site in enumerate(s.sites):
             if (self.min_oxi is None or site.specie.oxi_state >= self.min_oxi) and (
-                self.max_oxi is None or site.specie.oxi_state >= self.max_oxi
+                self.max_oxi is None or site.specie.oxi_state <= self.max_oxi
             ):
                 opvalstmp = self.site_featurizer.featurize(s, i)
                 for j, opval in enumerate(opvalstmp):


### PR DESCRIPTION
## Summary

max_oxi (maximum site oxidation state for inclusion) argument in SiteStatsFingerprint did not work due to typo in the if-condition. This PR fixes the typo.